### PR TITLE
Changed: Formatting of the build.sbt generated by maven2sbt

### DIFF
--- a/src/main/scala/io/kevinlee/maven2sbt/Maven2Sbt.scala
+++ b/src/main/scala/io/kevinlee/maven2sbt/Maven2Sbt.scala
@@ -81,9 +81,9 @@ object Maven2Sbt extends App {
       s"""resolvers += "${x.name}" at "${x.url}""""
     case x :: xs =>
       s"""resolvers ++= Seq(
-         |  "${x.name}" at "${x.url}",
-         |  ${xs.map(x => s""""${x.name}" at "${x.url}"""").mkString(",\n  ")}
-         |)
+         |    "${x.name}" at "${x.url}"
+         |  , ${xs.map(x => s""""${x.name}" at "${x.url}"""").mkString("\n  , ")}
+         |  )
          |""".stripMargin
   }
 
@@ -94,9 +94,9 @@ object Maven2Sbt extends App {
       s"""libraryDependencies += "${x.toDependencyString}"""
     case x :: xs =>
       s"""libraryDependencies ++= Seq(
-         |  ${x.toDependencyString},
-         |  ${xs.map(_.toDependencyString).mkString(",\n  ")}
-         |)
+         |    ${x.toDependencyString}
+         |  , ${xs.map(_.toDependencyString).mkString("\n  , ")}
+         |  )
          |""".stripMargin
   }
 
@@ -115,8 +115,7 @@ object Maven2Sbt extends App {
        |$resolvers
        |
        |$libraryDependencies
-       |
-     """.stripMargin
+       |""".stripMargin
 
   println(buildSbt)
 


### PR DESCRIPTION
From
```sbt
resolvers ++= Seq(
  "Kevin's Public Releases" at "http://dl.bintray.com/kevinlee/maven",
  "Kevin's Public Releases 2" at "http://blah.blah.blah/maven"
)


libraryDependencies ++= Seq(
  "junit" % "junit" % junitVersion % "test",
  "io.kevinlee" % "test0ster1" % test0ster1Version % "test",
  "io.kevinlee" % "nothing" % "0.0.1",
  "org.assertj" % "assertj-core" % "1.5.0" % "test",
  "org.mockito" % "mockito-all" % "1.9.5" % "test"
)
```
To
```sbt
resolvers ++= Seq(
    "Kevin's Public Releases" at "http://dl.bintray.com/kevinlee/maven"
  , "Kevin's Public Releases 2" at "http://blah.blah.blah/maven"
  )


libraryDependencies ++= Seq(
    "junit" % "junit" % junitVersion % "test"
  , "io.kevinlee" % "test0ster1" % test0ster1Version % "test"
  , "io.kevinlee" % "nothing" % "0.0.1"
  , "org.assertj" % "assertj-core" % "1.5.0" % "test"
  , "org.mockito" % "mockito-all" % "1.9.5" % "test"
  )
```