### PR TITLE
maven2sbt v0.1.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,11 +4,12 @@ import just.semver.SemVer
 import SemVer.{Major, Minor}
 
 val ProjectNamePrefix = "maven2sbt"
+val ProjectVersion = "0.1.0"
 val ProjectScalaVersion = "2.13.1"
 val CrossScalaVersions = Seq("2.10.7", "2.11.12", "2.12.10", ProjectScalaVersion)
 
 ThisBuild / organization := "io.kevinlee"
-ThisBuild / version := "0.1.0"
+ThisBuild / version := ProjectVersion
 ThisBuild / scalaVersion := ProjectScalaVersion
 ThisBuild / developers   := List(
   Developer("Kevin-Lee", "Kevin Lee", "kevin.code@kevinlee.io", url("https://github.com/Kevin-Lee"))

--- a/changelogs/0.1.0.md
+++ b/changelogs/0.1.0.md
@@ -1,0 +1,15 @@
+## [0.1.0](https://github.com/Kevin-Lee/maven2sbt/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+milestone%3Amilestone1) - 2019-12-08
+
+### Done
+* Create a `pom.xml` to `build.sbt` converter (#1)
+* Support exclusion (#3)
+* Clean up the code (#4)
+* Generate multi-project style `build.sbt` (#5)
+* Provide proper CLI (#9)
+* Remove hard-coded values and make them customizable (#25)
+* Create sub-projects for core and CLI (#27)
+* Rename package (#29)
+* Set up GitHub Actions to release both `core` lib and `cli` app (#34)
+
+### Fixed
+* Fix multiple GitHub Release issue (#37)


### PR DESCRIPTION
# maven2sbt v0.1.0

## [0.1.0](https://github.com/Kevin-Lee/maven2sbt/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+milestone%3Amilestone1) - 2019-12-08

### Done
* Create a `pom.xml` to `build.sbt` converter (#1)
* Support exclusion (#3)
* Clean up the code (#4)
* Generate multi-project style `build.sbt` (#5)
* Provide proper CLI (#9)
* Remove hard-coded values and make them customizable (#25)
* Create sub-projects for core and CLI (#27)
* Rename package (#29)
* Set up GitHub Actions to release both `core` lib and `cli` app (#34)

### Fixed
* Fix multiple GitHub Release issue (#37)
