### PR TITLE
Updated: README.md - easier ways to install maven2sbt-cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ A tool to convert Maven `pom.xml` into sbt `build.sbt`
 
 # Standalone CLI App
 
+It requires Java 8 or higher. So JRE should be installed and available to run `maven2sbt-cli`.
+
 ## Debian / Ubuntu Linux
 If you use Debian or Unbuntu Linux you can download [maven2sbt-cli_0.1.0_all.deb](https://github.com/Kevin-Lee/maven2sbt/releases/download/v0.1.0/maven2sbt-cli_0.1.0_all.deb) and install it.
 ```shell
@@ -25,17 +27,30 @@ $ which maven2sbt-cli
 ```
 
 
-## Linux / macOS (with Java)
+## Linux / macOS
+### Use `curl`
+```shell
+sh -c "$(curl -fsSL https://raw.githubusercontent.com/Kevin-Lee/maven2sbt/master/.scripts/install.sh)" 
+```
+***
 
+### Or use `wget`
+```shell
+sh -c "$(wget -O- https://raw.githubusercontent.com/Kevin-Lee/maven2sbt/master/.scripts/install.sh)" 
+```
+***
+
+### Or do it manually (not recommended)
+  
 Download [maven2sbt-cli-0.1.0.zip](https://github.com/Kevin-Lee/maven2sbt/releases/download/v0.1.0/maven2sbt-cli-0.1.0.zip) or [maven2sbt-cli-0.1.0.tgz](https://github.com/Kevin-Lee/maven2sbt/releases/download/v0.1.0/maven2sbt-cli-0.1.0.tgz) and unzip it.
-
+  
 Add an alias for convenience to `~/.zshrc` or `~/.bashrc` or `~/.bash_profile` or the run commands file for your shell. 
 ```shell
 alias maven2sbt-cli='/path/to/maven2sbt-cli-0.1.0/bin/maven2sbt-cli'
 ```
 
 
-## Windows (with Java / Not Tested)
+## Windows
 
 Download and unzip the maven2sbt-cli-0.1.0.zip or maven2sbt-cli-0.1.0.tgz just like Linux or macOS.
 


### PR DESCRIPTION
Updated: `README.md` - easier ways to install `maven2sbt-cli`