### PR TITLE
Removed: The context-applied compiler plugin

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -41,7 +41,6 @@ def subProject(projectName: String, path: File): Project =
     .settings(
         name := s"$ProjectNamePrefix-$projectName"
       , addCompilerPlugin("com.olegpy" %% "better-monadic-for" % "0.3.1")
-      , addCompilerPlugin("org.augustjune" %% "context-applied" % "0.1.2")
       , resolvers += hedgehogRepo
       , testFrameworks ++= Seq(TestFramework("hedgehog.sbt.Framework"))
       , libraryDependencies ++= hedgehogLibs


### PR DESCRIPTION
Removed: The `context-applied` compiler plugin as IntelliJ IDEA does not work well with it.