### PR TITLE
Fix #126 - Variables from maven properties are double-quoted

### DIFF
--- a/core/src/main/scala/maven2sbt/core/Dependency.scala
+++ b/core/src/main/scala/maven2sbt/core/Dependency.scala
@@ -52,7 +52,7 @@ object Dependency {
       val groupIdStr = MavenProperty.toPropertyNameOrItself(groupId)
       val artifactIdStr = MavenProperty.toPropertyNameOrItself(artifactId)
       val versionStr = MavenProperty.toPropertyNameOrItself(version)
-      s""""$groupIdStr" % "$artifactIdStr" % "$versionStr"${Scope.renderWithPrefix(" % ", scope)}${Exclusion.renderExclusions(exclusions)}"""
+      s"""$groupIdStr % $artifactIdStr % $versionStr${Scope.renderWithPrefix(" % ", scope)}${Exclusion.renderExclusions(exclusions)}"""
   }
 
   def renderLibraryDependencies(dependencies: Seq[Dependency], indentSize: Int): String = {

--- a/core/src/main/scala/maven2sbt/core/Exclusion.scala
+++ b/core/src/main/scala/maven2sbt/core/Exclusion.scala
@@ -14,7 +14,7 @@ object Exclusion {
     case Exclusion(GroupId(groupId), ArtifactId(artifactId)) =>
       val groupIdStr = MavenProperty.toPropertyNameOrItself(groupId)
       val artifactIdStr = MavenProperty.toPropertyNameOrItself(artifactId)
-      s"""ExclusionRule(organization = "$groupIdStr", artifact = "$artifactIdStr")"""
+      s"""ExclusionRule(organization = $groupIdStr, artifact = $artifactIdStr)"""
   }
 
   def renderExclusions(exclusions: Seq[Exclusion]): String = exclusions match {

--- a/core/src/main/scala/maven2sbt/core/MavenProperty.scala
+++ b/core/src/main/scala/maven2sbt/core/MavenProperty.scala
@@ -26,5 +26,5 @@ object MavenProperty {
   }
 
   def toPropertyNameOrItself(name: String): String =
-    findPropertyName(name).fold(name)(dotSeparatedToCamelCase)
+    findPropertyName(name).fold(s""""$name"""")(dotSeparatedToCamelCase)
 }


### PR DESCRIPTION
Fix #126 - Variables from maven properties are double-quoted