### PR TITLE
Fix #125 - Maven property name with hyphens is not converted to Scala variable name properly

### DIFF
--- a/core/src/main/scala/maven2sbt/core/BuildSbt.scala
+++ b/core/src/main/scala/maven2sbt/core/BuildSbt.scala
@@ -99,7 +99,7 @@ object BuildSbt {
       Prop(PropName(mavenProperty.key), PropValue(mavenProperty.value))
 
     def render(prop: Prop): String =
-      s"""val ${Common.dotSeparatedToCamelCase(prop.name.propName)} = "${prop.value.propValue}""""
+      s"""val ${Common.dotHyphenSeparatedToCamelCase(prop.name.propName)} = "${prop.value.propValue}""""
   }
 
   def render(buildSbt: BuildSbt): String = buildSbt match {

--- a/core/src/main/scala/maven2sbt/core/Common.scala
+++ b/core/src/main/scala/maven2sbt/core/Common.scala
@@ -8,10 +8,10 @@ import scala.util.matching.Regex
   */
 sealed trait Common {
 
-  val dotSeparatedPattern: Regex = """\$\{(.+)\}""".r
+  val propertyUsagePattern: Regex = """\$\{(.+)\}""".r
 
-  def dotSeparatedToCamelCase(dotSeparated: String): String = {
-    val names = dotSeparated.trim.split("\\.")
+  def dotHyphenSeparatedToCamelCase(dotSeparated: String): String = {
+    val names = dotSeparated.trim.split("[\\.-]+")
     if (names.length == 1)
       dotSeparated
     else

--- a/core/src/main/scala/maven2sbt/core/MavenProperty.scala
+++ b/core/src/main/scala/maven2sbt/core/MavenProperty.scala
@@ -18,13 +18,13 @@ object MavenProperty {
   } yield MavenProperty(label, property.text)
 
   def render(property: MavenProperty): String =
-    s"""val ${dotSeparatedToCamelCase(property.key)} = "${property.value}""""
+    s"""val ${dotHyphenSeparatedToCamelCase(property.key)} = "${property.value}""""
 
   def findPropertyName(name: String): Option[String] = name match {
-    case dotSeparatedPattern(value) => Some(value.trim)
+    case propertyUsagePattern(value) => Some(value.trim)
     case _ => None
   }
 
   def toPropertyNameOrItself(name: String): String =
-    findPropertyName(name).fold(s""""$name"""")(dotSeparatedToCamelCase)
+    findPropertyName(name).fold(s""""$name"""")(dotHyphenSeparatedToCamelCase)
 }

--- a/core/src/test/resources/pom.xml
+++ b/core/src/test/resources/pom.xml
@@ -12,10 +12,14 @@
   <url>https://github.com/Kevin-Lee/j8plus</url>
 
   <properties>
+    <something>blah-blah-blah</something>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <java.version>1.8</java.version>
     <junit.version>4.11</junit.version>
+    <exclude-project.group>dont-try-this</exclude-project.group>
+    <exclude-project.name>home</exclude-project.name>
     <test0ster1.version>0.0.6</test0ster1.version>
+    <some-test-property.version>1.2.3</some-test-property.version>
   </properties>
 
   <repositories>
@@ -145,6 +149,16 @@
       <version>1.5.0</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>my.group</groupId>
+      <artifactId>fake-app</artifactId>
+      <version>${some-test-property.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>my.group</groupId>
+      <artifactId>${ something }</artifactId>
+      <version>${some-test-property.version}</version>
+    </dependency>
 
     <dependency>
       <groupId>some.project</groupId>
@@ -183,8 +197,8 @@
           <artifactId>abc</artifactId>
         </exclusion>
         <exclusion>
-          <groupId>some.test</groupId>
-          <artifactId>project-123</artifactId>
+          <groupId>${exclude-project.group}</groupId>
+          <artifactId>${exclude-project.name}</artifactId>
         </exclusion>
         <exclusion>
           <groupId>something.else</groupId>

--- a/core/src/test/scala/maven2sbt/core/CommonSpec.scala
+++ b/core/src/test/scala/maven2sbt/core/CommonSpec.scala
@@ -24,7 +24,7 @@ object CommonSpec extends Properties {
   def testDotSeparatedToCamelCase1: Property = for {
     name <- Gen.string(Gen.alphaNum, Range.linear(1, 10)).log("name")
   } yield {
-    val actual = Common.dotSeparatedToCamelCase(name)
+    val actual = Common.dotHyphenSeparatedToCamelCase(name)
     actual ==== name
   }
   def testDotSeparatedToCamelCaseMore: Property = for {
@@ -32,7 +32,7 @@ object CommonSpec extends Properties {
   } yield {
     val dotSeparatedName = names.mkString(".")
     val expected = (names.head :: names.drop(1).map(_.capitalize)).mkString
-    val actual = Common.dotSeparatedToCamelCase(dotSeparatedName)
+    val actual = Common.dotHyphenSeparatedToCamelCase(dotSeparatedName)
     actual ==== expected
   }
 }

--- a/core/src/test/scala/maven2sbt/core/Gens.scala
+++ b/core/src/test/scala/maven2sbt/core/Gens.scala
@@ -9,6 +9,8 @@ import maven2sbt.core.Repository.{RepoId, RepoName, RepoUrl}
   */
 object Gens {
 
+  final case class ExpectedMavenProperty(expectedMavenProperty: MavenProperty) extends AnyVal
+
   def genGroupId: Gen[GroupId] = Gen.string(Gen.alphaNum, Range.linear(1, 10)).map(GroupId)
   def genArtifactId: Gen[ArtifactId] = Gen.string(Gen.alphaNum, Range.linear(1, 10)).map(ArtifactId)
   def genVersion: Gen[Version] = Gen.string(Gen.alphaNum, Range.linear(1, 10)).map(Version)
@@ -41,9 +43,29 @@ object Gens {
   } yield Repository(id, name, url)
 
   def genMavenProperty: Gen[MavenProperty] = for {
-    key <- Gen.string(Gen.alphaNum, Range.linear(1, 10))
+    keyFirst <- Gen.string(Gen.choice1(Gen.alpha, Gen.constant('_')), Range.singleton(1))
+    keyHead <- Gen.string(Gen.choice1(Gen.alphaNum), Range.linear(1, 10))
+        .list(Range.singleton(1)).map(keyFirst :: _)
+    keyList <- Gen.string(Gen.frequency1(8 -> Gen.alphaNum, 2 -> Gen.constant('_')), Range.linear(0, 10))
+        .list(Range.linear(3, 5)).map(keyHead ++ _)
+    delimiterList <- Gen.string(Gen.element1('.', '-'), Range.singleton(1))
+        .list(Range.singleton(keyList.length - 1))
+    key = keyList.zip(delimiterList :+ "").map { case (word, delimiter) => word + delimiter }.mkString
     value <- Gen.string(Gen.unicode, Range.linear(1, 50))
   } yield MavenProperty(key, value)
+
+  def genMavenPropertyWithExpectedRendered: Gen[(ExpectedMavenProperty, MavenProperty)] = for {
+    keyFirst <- Gen.string(Gen.choice1(Gen.alpha, Gen.constant('_')), Range.singleton(1))
+    keyHead <- Gen.string(Gen.choice1(Gen.alphaNum), Range.linear(1, 10))
+        .list(Range.singleton(1)).map(keyFirst :: _)
+    keyList <- Gen.string(Gen.frequency1(8 -> Gen.alphaNum, 2 -> Gen.constant('_')), Range.linear(0, 10))
+        .list(Range.linear(3, 5)).map(keyHead ++ _)
+    delimiterList <- Gen.string(Gen.element1('.', '-'), Range.singleton(1))
+        .list(Range.singleton(keyList.length - 1))
+    key = keyList.zip(delimiterList :+ "").map { case (word, delimiter) => word + delimiter }.mkString
+    expectedKey = (keyList.headOption.toList ++ keyList.drop(1).map(_.capitalize)).mkString
+    value <- Gen.string(Gen.unicode, Range.linear(1, 50))
+  } yield (ExpectedMavenProperty(MavenProperty(expectedKey, value)), MavenProperty(key, value))
 
   def genScope: Gen[Scope] =
     Gen.element1(Scope.compile, Scope.test, Scope.provided, Scope.runtime, Scope.system, Scope.default)

--- a/core/src/test/scala/maven2sbt/core/MavenPropertySpec.scala
+++ b/core/src/test/scala/maven2sbt/core/MavenPropertySpec.scala
@@ -39,10 +39,11 @@ object MavenPropertySpec extends Properties {
   }
 
   def testRender: Property = for {
-    mavenProperty <- Gens.genMavenProperty.log("mavenProperty")
+    (Gens.ExpectedMavenProperty(expectedProperty), mavenProperty) <- Gens.genMavenPropertyWithExpectedRendered.log("mavenProperty")
   } yield {
-    val expected = s"""val ${mavenProperty.key} = "${mavenProperty.value}""""
+    val expected = s"""val ${expectedProperty.key} = "${expectedProperty.value}""""
     val actual = MavenProperty.render(mavenProperty)
     actual ==== expected
   }
+
 }


### PR DESCRIPTION
Fix #125 - Maven property name with hyphens is not converted to Scala variable name properly