### PR TITLE
maven2sbt v1.0.0

### DIFF
--- a/.scripts/install.sh
+++ b/.scripts/install.sh
@@ -4,7 +4,7 @@ set -eu
 
 app_executable_name=maven2sbt
 app_name=maven2sbt-cli
-app_version=${1:-0.4.0}
+app_version=${1:-1.0.0}
 versioned_app_name="${app_name}-${app_version}"
 app_zip_file="${versioned_app_name}.zip"
 download_url="https://github.com/Kevin-Lee/maven2sbt/releases/download/v${app_version}/${app_zip_file}"

--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,7 @@ import SemVer.{Major, Minor}
 val GitHubUsername = "Kevin-Lee"
 val RepoName = "maven2sbt"
 val ExecutableScriptName = RepoName
-val ProjectVersion = "0.4.0"
+val ProjectVersion = "1.0.0"
 val ProjectScalaVersion = "2.13.3"
 val CrossScalaVersions = Seq("2.11.12", "2.12.12", ProjectScalaVersion)
 

--- a/changelogs/1.0.0.md
+++ b/changelogs/1.0.0.md
@@ -1,0 +1,12 @@
+## [1.0.0](https://github.com/Kevin-Lee/maven2sbt/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+milestone%3Amilestone5) - 2020-09-07
+
+### Done
+* Use newtype instead of value class (#132)
+* Deprecate render methods no longer in use (#130)
+* Use Effectie (#108)
+* Maven2Sbt should return modeled data instead of `String` (#95)
+
+### Fixed
+* Variables from maven properties are double-quoted (#126)
+* Maven property name with hyphens is not converted to Scala variable name properly (#125)
+* Maven2Sbt is not referentially transparent (#91)

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -12,4 +12,4 @@ addSbtPlugin("io.kevinlee" % "sbt-devoops" % "1.0.3")
 
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.9.0")
 
-addSbtPlugin("io.kevinlee" % "sbt-docusaur" % "0.1.2")
+addSbtPlugin("io.kevinlee" % "sbt-docusaur" % "0.1.4")


### PR DESCRIPTION
# maven2sbt v1.0.0
## [1.0.0](https://github.com/Kevin-Lee/maven2sbt/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+milestone%3Amilestone5) - 2020-09-07

### Done
* Use newtype instead of value class (#132)
* Deprecate render methods no longer in use (#130)
* Use Effectie (#108)
* Maven2Sbt should return modeled data instead of `String` (#95)

### Fixed
* Variables from maven properties are double-quoted (#126)
* Maven property name with hyphens is not converted to Scala variable name properly (#125)
* Maven2Sbt is not referentially transparent (#91)
