### PR TITLE
Fix #147 - possible reserved sbt words used as property names (e.g. scalaVersion, version, etc.)

### DIFF
--- a/core/src/main/scala/maven2sbt/core/BuildSbt.scala
+++ b/core/src/main/scala/maven2sbt/core/BuildSbt.scala
@@ -1,9 +1,7 @@
 package maven2sbt.core
 
 import BuildSbt._
-
 import cats.syntax.all._
-
 import just.fp.{Named, Render}
 
 /**
@@ -94,22 +92,6 @@ object BuildSbt {
       Settings.render(globalSettings.globalSettings, "Global / ".some, "\n", 2)
   }
 
-  final case class Prop(name: PropName, value: PropValue)
-  final case class PropName(propName: String) extends AnyVal
-  final case class PropValue(propValue: String) extends AnyVal
-
-  object Prop {
-
-    def fromMavenProperty(mavenProperty: MavenProperty): Prop =
-      Prop(
-        PropName(Common.dotHyphenSeparatedToCamelCase(mavenProperty.key)),
-        PropValue(mavenProperty.value)
-      )
-
-    def render(prop: Prop): String =
-      s"""val ${prop.name.propName} = "${prop.value.propValue}""""
-  }
-
   def render(buildSbt: BuildSbt): String = buildSbt match {
     case BuildSbt(
         globalSettings
@@ -123,7 +105,7 @@ object BuildSbt {
       val projectSettingsRendered = ProjectSettings.render(projectSettings)
 
       s"""
-         |${props.map(Prop.render).mkString("\n")}
+         |${Props.renderProps(Props.PropsName("props"), 2, props)}
          |
          |$globalSettingsRendered
          |$thisBuildSettingsRendered

--- a/core/src/main/scala/maven2sbt/core/Dependency.scala
+++ b/core/src/main/scala/maven2sbt/core/Dependency.scala
@@ -48,10 +48,11 @@ object Dependency {
 
   def render(dependency: Dependency): String = dependency match {
     case Dependency(GroupId(groupId), ArtifactId(artifactId), Version(version), scope, exclusions) =>
-      val groupIdStr = MavenProperty.toPropertyNameOrItself(groupId)
-      val artifactIdStr = MavenProperty.toPropertyNameOrItself(artifactId)
-      val versionStr = MavenProperty.toPropertyNameOrItself(version)
-      s"""$groupIdStr % $artifactIdStr % $versionStr${Scope.renderWithPrefix(" % ", scope)}${Exclusion.renderExclusions(exclusions)}"""
+      val propsName = Props.PropsName("props")
+      val groupIdStr = MavenProperty.toPropertyNameOrItself(propsName, groupId)
+      val artifactIdStr = MavenProperty.toPropertyNameOrItself(propsName, artifactId)
+      val versionStr = MavenProperty.toPropertyNameOrItself(propsName, version)
+      s"""$groupIdStr % $artifactIdStr % $versionStr${Scope.renderWithPrefix(" % ", scope)}${Exclusion.renderExclusions(propsName, exclusions)}"""
   }
 
 }

--- a/core/src/main/scala/maven2sbt/core/Exclusion.scala
+++ b/core/src/main/scala/maven2sbt/core/Exclusion.scala
@@ -10,23 +10,24 @@ final case class Exclusion(groupId: GroupId, artifactId: ArtifactId)
 
 object Exclusion {
 
-  def renderExclusionRule(exclusion: Exclusion): String = exclusion match {
+  def renderExclusionRule(propsName: Props.PropsName, exclusion: Exclusion): String = exclusion match {
     case Exclusion(groupId, artifactId) =>
-      val groupIdStr = MavenProperty.toPropertyNameOrItself(groupId.groupId)
-      val artifactIdStr = MavenProperty.toPropertyNameOrItself(artifactId.artifactId)
+      val groupIdStr = MavenProperty.toPropertyNameOrItself(propsName, groupId.groupId)
+      val artifactIdStr = MavenProperty.toPropertyNameOrItself(propsName, artifactId.artifactId)
       s"""ExclusionRule(organization = $groupIdStr, artifact = $artifactIdStr)"""
   }
 
-  def renderExclusions(exclusions: Seq[Exclusion]): String = exclusions match {
+  def renderExclusions(propsName: Props.PropsName, exclusions: Seq[Exclusion]): String = exclusions match {
     case Nil =>
       ""
     case Exclusion(groupId, artifactId) :: Nil =>
-      s""" exclude("${groupId.groupId}", "${artifactId.artifactId}")"""
+      s""" exclude(${MavenProperty.toPropertyNameOrItself(propsName, groupId.groupId)}, """ +
+        s"""${MavenProperty.toPropertyNameOrItself(propsName, artifactId.artifactId)})"""
     case x :: xs =>
       val idt = indent(8)
       s""" excludeAll(
-         |$idt  ${renderExclusionRule(x)},
-         |$idt  ${xs.map(renderExclusionRule).mkString(s",\n$idt  ")}
+         |$idt  ${renderExclusionRule(propsName, x)},
+         |$idt  ${xs.map(renderExclusionRule(propsName, _)).mkString(s",\n$idt  ")}
          |$idt)""".stripMargin
   }
 }

--- a/core/src/main/scala/maven2sbt/core/Maven2Sbt.scala
+++ b/core/src/main/scala/maven2sbt/core/Maven2Sbt.scala
@@ -34,7 +34,7 @@ object Maven2Sbt {
         pom <- effectOf(pomElem)
         ProjectInfo(groupId, artifactId, version) <- effectOf(ProjectInfo.from(pom))
         mavenProperties <- effectOf(MavenProperty.from(pom))
-        props <- effectOf(mavenProperties.map(BuildSbt.Prop.fromMavenProperty))
+        props <- effectOf(mavenProperties.map(Prop.fromMavenProperty))
         repositories <- effectOf(Repository.from(pom))
         dependencies <- effectOf(Dependency.from(pom))
         globalSettings <- pureOf(BuildSbt.GlobalSettings.empty)

--- a/core/src/main/scala/maven2sbt/core/MavenProperty.scala
+++ b/core/src/main/scala/maven2sbt/core/MavenProperty.scala
@@ -22,6 +22,9 @@ object MavenProperty {
     case _ => None
   }
 
-  def toPropertyNameOrItself(name: String): String =
-    findPropertyName(name).fold(s""""$name"""")(dotHyphenSeparatedToCamelCase)
+  def toPropertyNameOrItself(propsName: Props.PropsName, name: String): String =
+    findPropertyName(name)
+      .fold(s""""$name"""")(dotSeparated =>
+        s"${propsName.propsName}.${dotHyphenSeparatedToCamelCase(dotSeparated)}"
+      )
 }

--- a/core/src/main/scala/maven2sbt/core/Props.scala
+++ b/core/src/main/scala/maven2sbt/core/Props.scala
@@ -1,0 +1,38 @@
+package maven2sbt.core
+
+import io.estatico.newtype.macros.newtype
+
+import scala.language.implicitConversions
+
+/**
+ * @author Kevin Lee
+ * @since 2020-12-13
+ */
+object Props {
+  @newtype case class PropsName(propsName: String)
+
+  def renderProps(propsNmae: PropsName, indentSize: Int, props: List[Prop]): String = {
+    val indent = " " * indentSize
+    props.map { prop =>
+      s"""val ${prop.name.propName} = "${prop.value.propValue}""""
+    }.mkString(s"lazy val ${propsNmae.propsName} = new {\n$indent", s"\n$indent", s"\n}")
+  }
+
+}
+
+final case class Prop(name: Prop.PropName, value: Prop.PropValue)
+
+object Prop {
+  final case class PropName(propName: String) extends AnyVal
+  final case class PropValue(propValue: String) extends AnyVal
+
+  def fromMavenProperty(mavenProperty: MavenProperty): Prop =
+    Prop(
+      PropName(Common.dotHyphenSeparatedToCamelCase(mavenProperty.key)),
+      PropValue(mavenProperty.value)
+    )
+
+  def render(prop: Prop): String =
+    s"""val ${prop.name.propName} = "${prop.value.propValue}""""
+
+}

--- a/core/src/test/scala/maven2sbt/core/BuildSbtSpec.scala
+++ b/core/src/test/scala/maven2sbt/core/BuildSbtSpec.scala
@@ -1,19 +1,15 @@
 package maven2sbt.core
 
 import cats.syntax.all._
-
 import hedgehog._
 import hedgehog.runner._
-
-import maven2sbt.core.Gens.ExpectedMavenProperty
 
 /**
  * @author Kevin Lee
  * @since 2020-09-05
  */
 object BuildSbtSpec extends Properties {
-  override def tests: List[Prop] = List(
-    property("test BuildSbt.Prop.fromMavenProperty", PropSpec.testFromMavenProperty),
+  override def tests: List[Test] = List(
     property(
       "[Render][Repository] test BuildSbt.renderListOfFieldValue(None, List.empty[Repository], n)",
       RenderRepositorySpec.testRenderToResolvers0
@@ -72,26 +68,6 @@ object BuildSbtSpec extends Properties {
     )
   )
 
-  object PropSpec {
-
-    def testFromMavenProperty: Property = for {
-      mavenProperties <- Gens.genMavenPropertyWithExpectedRendered.list(Range.linear(0, 10))
-          .log("mavenProperties")
-    } yield {
-      val (expected, actual) = mavenProperties.map {
-        case (ExpectedMavenProperty(expectedMavenProperty), mavenProperty) =>
-          (
-            BuildSbt.Prop(
-                BuildSbt.PropName(expectedMavenProperty.key),
-                BuildSbt.PropValue(expectedMavenProperty.value)
-              ),
-            BuildSbt.Prop.fromMavenProperty(mavenProperty)
-          )
-      }.unzip
-      actual ==== expected
-    }
-
-  }
 
   object RenderRepositorySpec {
 

--- a/core/src/test/scala/maven2sbt/core/DependencySpec.scala
+++ b/core/src/test/scala/maven2sbt/core/DependencySpec.scala
@@ -58,8 +58,9 @@ object DependencySpec extends Properties {
   def testRender: Property = for {
     dependency <- Gens.genDependency.log("dependency")
   } yield {
+    val propsName = Props.PropsName("props")
     val Dependency(GroupId(groupId), ArtifactId(artifactId), Version(version), scope, exclusions) = dependency
-    val expected = s""""$groupId" % "$artifactId" % "$version"${Scope.renderWithPrefix(" % ", scope)}${Exclusion.renderExclusions(exclusions)}"""
+    val expected = s""""$groupId" % "$artifactId" % "$version"${Scope.renderWithPrefix(" % ", scope)}${Exclusion.renderExclusions(propsName, exclusions)}"""
     val actual = Dependency.render(dependency)
     actual ==== expected
   }

--- a/core/src/test/scala/maven2sbt/core/ExclusionSpec.scala
+++ b/core/src/test/scala/maven2sbt/core/ExclusionSpec.scala
@@ -16,17 +16,19 @@ object ExclusionSpec extends Properties {
   , property("test renderExclusions with more than two exclusions", testRenderExclusionsMoreThanTwo)
   )
 
+  private val propsName = Props.PropsName("testProps")
+
   def testRenderExclusionRule: Property = for {
     exclusion <- Gens.genExclusion.log("exclusion")
   } yield {
     val expected = s"""ExclusionRule(organization = "${exclusion.groupId.groupId}", artifact = "${exclusion.artifactId.artifactId}")"""
-    val actual = Exclusion.renderExclusionRule(exclusion)
+    val actual = Exclusion.renderExclusionRule(propsName, exclusion)
     actual ==== expected
   }
 
   def testRenderExclusions0: Result = {
     val expected = ""
-    val actual = Exclusion.renderExclusions(List.empty)
+    val actual = Exclusion.renderExclusions(propsName, List.empty)
     actual ==== expected
   }
 
@@ -34,7 +36,7 @@ object ExclusionSpec extends Properties {
     exclusion <- Gens.genExclusion.log("exclusion")
   } yield {
     val expected = s""" exclude("${exclusion.groupId.groupId}", "${exclusion.artifactId.artifactId}")"""
-    val actual = Exclusion.renderExclusions(List(exclusion))
+    val actual = Exclusion.renderExclusions(propsName, List(exclusion))
     actual ==== expected
   }
 
@@ -44,9 +46,9 @@ object ExclusionSpec extends Properties {
     val indent = " " * 8
     val expected =
       s""" excludeAll(
-         |$indent  ${exclusions.map(Exclusion.renderExclusionRule).mkString(s",\n$indent  ")}
+         |$indent  ${exclusions.map(Exclusion.renderExclusionRule(propsName, _)).mkString(s",\n$indent  ")}
          |$indent)""".stripMargin
-    val actual = Exclusion.renderExclusions(exclusions)
+    val actual = Exclusion.renderExclusions(propsName, exclusions)
     actual ==== expected
   }
 
@@ -56,9 +58,9 @@ object ExclusionSpec extends Properties {
     val indent = " " * 8
     val expected =
       s""" excludeAll(
-         |$indent  ${exclusions.map(Exclusion.renderExclusionRule).mkString(s",\n$indent  ")}
+         |$indent  ${exclusions.map(Exclusion.renderExclusionRule(propsName, _)).mkString(s",\n$indent  ")}
          |$indent)""".stripMargin
-    val actual = Exclusion.renderExclusions(exclusions)
+    val actual = Exclusion.renderExclusions(propsName, exclusions)
     actual ==== expected
   }
 

--- a/core/src/test/scala/maven2sbt/core/PropSpec.scala
+++ b/core/src/test/scala/maven2sbt/core/PropSpec.scala
@@ -1,0 +1,47 @@
+package maven2sbt.core
+
+import hedgehog._
+import hedgehog.runner._
+import maven2sbt.core.Gens.ExpectedMavenProperty
+import maven2sbt.core.{Prop => M2sProp}
+
+object PropSpec extends Properties {
+
+  override def tests: List[Test] = List(
+    property("test Prop.fromMavenProperty", PropSpec.testFromMavenProperty),
+    property("test Prop.render(prop)", PropSpec.testRender)
+  )
+
+  def testFromMavenProperty: Property = for {
+      mavenProperties <- Gens.genMavenPropertyWithExpectedRendered.list(Range.linear(0, 10))
+          .log("mavenProperties")
+    } yield {
+      val (expected, actual) = mavenProperties.map {
+        case (ExpectedMavenProperty(expectedMavenProperty), mavenProperty) =>
+          (
+            M2sProp(
+              M2sProp.PropName(expectedMavenProperty.key),
+              M2sProp.PropValue(expectedMavenProperty.value)
+            ),
+            M2sProp.fromMavenProperty(mavenProperty)
+          )
+      }.unzip
+      actual ==== expected
+    }
+
+  def testRender: Property = for {
+    mavenProperty <- Gens.genMavenPropertyWithExpectedRendered.log("mavenProperty")
+  } yield {
+    val (expected, prop) =
+      mavenProperty match {
+        case (ExpectedMavenProperty(expectedMavenProperty), mavenProperty) =>
+          (
+            s"""val ${expectedMavenProperty.key} = "${expectedMavenProperty.value}"""",
+            M2sProp.fromMavenProperty(mavenProperty)
+          )
+      }
+    val actual = M2sProp.render(prop)
+    actual ==== expected
+  }
+
+}

--- a/core/src/test/scala/maven2sbt/core/PropsSpec.scala
+++ b/core/src/test/scala/maven2sbt/core/PropsSpec.scala
@@ -1,0 +1,36 @@
+package maven2sbt.core
+
+import hedgehog._
+import hedgehog.runner._
+import maven2sbt.core.Gens.ExpectedMavenProperty
+import maven2sbt.core.{Prop => M2sProp}
+
+/**
+ * @author Kevin Lee
+ * @since 2020-12-13
+ */
+object PropsSpec extends Properties {
+  override def tests: List[Test] = List(
+    property("test Props.render", testPropsRender)
+  )
+
+  def testPropsRender: Property = for {
+    mavenProperties <- Gens.genMavenPropertyWithExpectedRendered
+        .list(Range.linear(1, 10))
+        .log("mavenProperties")
+    indentSize <- Gen.int(Range.linear(0, 8)).log("indent")
+  } yield {
+    val (propsRendered, props) = mavenProperties.map {
+      case (ExpectedMavenProperty(MavenProperty(expectedKey, expectedValue)), mavenProperty) =>
+        (
+          s"""val $expectedKey = "${expectedValue}"""",
+          M2sProp.fromMavenProperty(mavenProperty)
+        )
+    }.unzip
+    val propsName = Props.PropsName("testProps")
+    val indent = " " * indentSize
+    val expected = propsRendered.mkString(s"lazy val $propsName = new {\n$indent", s"\n$indent", "\n}")
+    val actual = Props.renderProps(propsName, indentSize, props)
+    actual ==== expected
+  }
+}


### PR DESCRIPTION
Fix #147 - possible reserved sbt words used as property names (e.g. `scalaVersion`, `version`, etc.)