### PR TITLE
Fix #158 - The wrong named parameter (i.e. artifact) was used in ExclusionRule - replaced with name

### DIFF
--- a/core/src/main/scala/maven2sbt/core/Exclusion.scala
+++ b/core/src/main/scala/maven2sbt/core/Exclusion.scala
@@ -14,7 +14,7 @@ object Exclusion {
     case Exclusion(groupId, artifactId) =>
       val groupIdStr = MavenProperty.toPropertyNameOrItself(propsName, groupId.groupId)
       val artifactIdStr = MavenProperty.toPropertyNameOrItself(propsName, artifactId.artifactId)
-      s"""ExclusionRule(organization = $groupIdStr, artifact = $artifactIdStr)"""
+      s"""ExclusionRule(organization = $groupIdStr, name = $artifactIdStr)"""
   }
 
   def renderExclusions(propsName: Props.PropsName, exclusions: Seq[Exclusion]): String = exclusions match {

--- a/core/src/test/scala/maven2sbt/core/ExclusionSpec.scala
+++ b/core/src/test/scala/maven2sbt/core/ExclusionSpec.scala
@@ -21,7 +21,7 @@ object ExclusionSpec extends Properties {
   def testRenderExclusionRule: Property = for {
     exclusion <- Gens.genExclusion.log("exclusion")
   } yield {
-    val expected = s"""ExclusionRule(organization = "${exclusion.groupId.groupId}", artifact = "${exclusion.artifactId.artifactId}")"""
+    val expected = s"""ExclusionRule(organization = "${exclusion.groupId.groupId}", name = "${exclusion.artifactId.artifactId}")"""
     val actual = Exclusion.renderExclusionRule(propsName, exclusion)
     actual ==== expected
   }


### PR DESCRIPTION
Fix #158 - The wrong named parameter (i.e. `artifact`) was used in `ExclusionRule` - replaced with `name`