### PR TITLE
Added: stringsMkString to replace mkString to make sure Seq[A] is Seq[String] when mkString

### DIFF
--- a/core/src/main/scala/maven2sbt/core/BuildSbt.scala
+++ b/core/src/main/scala/maven2sbt/core/BuildSbt.scala
@@ -47,7 +47,7 @@ object BuildSbt {
         val idt = indent(indentSize)
         s"""${prefix.getOrElse("")}${Named[A].name} ++= List(
            |$idt  ${Render[A].render(propsName, x).toQuotedString},
-           |$idt  ${xs.map(eachX => Render[A].render(propsName, eachX).toQuotedString).mkString(s",\n$idt  ")}
+           |$idt  ${xs.map(eachX => Render[A].render(propsName, eachX).toQuotedString).stringsMkString(s",\n$idt  ")}
            |$idt)""".stripMargin.some
     }
 
@@ -61,7 +61,7 @@ object BuildSbt {
         renderListOfFieldValue(prefix, propsName, settings.repositories, indentSize).toList ++
         renderListOfFieldValue(prefix, propsName, settings.dependencies, indentSize).toList
       )
-      .mkString(delimiter)
+      .stringsMkString(delimiter)
   }
 
   final case class ProjectSettings(projectSettings: Settings) extends AnyVal

--- a/core/src/main/scala/maven2sbt/core/Exclusion.scala
+++ b/core/src/main/scala/maven2sbt/core/Exclusion.scala
@@ -40,7 +40,7 @@ object Exclusion {
       RenderedString.noQuotesRequired(
         s""" excludeAll(
            |$idt  ${Render[Exclusion].render(propsName, x).toQuotedString},
-           |$idt  ${xs.map(Render[Exclusion].render(propsName, _).toQuotedString).mkString(s",\n$idt  ")}
+           |$idt  ${xs.map(Render[Exclusion].render(propsName, _).toQuotedString).stringsMkString(s",\n$idt  ")}
            |$idt)""".stripMargin
       )
   }

--- a/core/src/main/scala/maven2sbt/core/Props.scala
+++ b/core/src/main/scala/maven2sbt/core/Props.scala
@@ -16,7 +16,7 @@ object Props {
   def renderProps(propsNmae: PropsName, indentSize: Int, props: List[Prop]): String = {
     val indent = StringUtils.indent(indentSize)
     props.map(Prop.render(propsNmae, _).toQuotedString)
-      .mkString(s"lazy val ${propsNmae.propsName} = new {\n$indent", s"\n$indent", s"\n}")
+      .stringsMkString(s"lazy val ${propsNmae.propsName} = new {\n$indent", s"\n$indent", s"\n}")
   }
 
 }

--- a/core/src/main/scala/maven2sbt/core/core.scala
+++ b/core/src/main/scala/maven2sbt/core/core.scala
@@ -89,7 +89,7 @@ package object core {
 
   }
 
-  implicit class RenderedStringOps(val s: RenderedString) extends AnyVal {
+  implicit final class RenderedStringOps(val s: RenderedString) extends AnyVal {
     def toQuotedString: String =
       StringUtils.quoteRenderedString(s)
 
@@ -100,4 +100,15 @@ package object core {
     }
   }
 
+  @SuppressWarnings(Array("org.wartremover.warts.Overloading"))
+  implicit final class MkStringForOnlyStrings(val stringList: Seq[String]) extends AnyVal {
+    def stringsMkString: String =
+      stringList.mkString
+
+    def stringsMkString(sep: String): String =
+      stringList.mkString(sep)
+
+    def stringsMkString(start: String, sep: String, end: String): String =
+      stringList.mkString(start, sep, end)
+  }
 }

--- a/core/src/test/scala/maven2sbt/core/BuildSbtSpec.scala
+++ b/core/src/test/scala/maven2sbt/core/BuildSbtSpec.scala
@@ -195,7 +195,7 @@ object BuildSbtSpec extends Properties {
       val idt = StringUtils.indent(n)
       val expected =
         s"""resolvers ++= List(
-           |$idt${repositories.map(repo => Repository.render(propsName, repo).toQuotedString).mkString("  ", s",\n$idt  ", "")}
+           |$idt${repositories.map(repo => Repository.render(propsName, repo).toQuotedString).stringsMkString("  ", s",\n$idt  ", "")}
            |$idt)""".stripMargin.some
       val actual = BuildSbt.renderListOfFieldValue(none[String], propsName, repositories, n)
       actual ==== expected
@@ -210,8 +210,8 @@ object BuildSbtSpec extends Properties {
       val idt = StringUtils.indent(n)
       val expected =
         s"""resolvers ++= List(
-           |$idt${repositories.map(repo => Repository.render(propsName, repo).toQuotedString).mkString("  ", s",\n$idt  ", ",")}
-           |$idt${repositoriesWithEmptyNames.map(repo => Repository.render(propsName, repo).toQuotedString).mkString("  ", s",\n$idt  ", "")}
+           |$idt${repositories.map(repo => Repository.render(propsName, repo).toQuotedString).stringsMkString("  ", s",\n$idt  ", ",")}
+           |$idt${repositoriesWithEmptyNames.map(repo => Repository.render(propsName, repo).toQuotedString).stringsMkString("  ", s",\n$idt  ", "")}
            |$idt)""".stripMargin.some
       val input = repositories ++ repositoriesWithEmptyNames
       val actual = BuildSbt.renderListOfFieldValue(none[String], propsName, input, n)
@@ -227,8 +227,8 @@ object BuildSbtSpec extends Properties {
       val idt = StringUtils.indent(n)
       val expected =
         s"""resolvers ++= List(
-           |$idt${repositories.map(repo => Repository.render(propsName, repo).toQuotedString).mkString("  ", s",\n$idt  ", ",")}
-           |$idt${repositoriesWithEmptyNames.map(repo => Repository.render(propsName, repo).toQuotedString).mkString("  ", s",\n$idt  ", "")}
+           |$idt${repositories.map(repo => Repository.render(propsName, repo).toQuotedString).stringsMkString("  ", s",\n$idt  ", ",")}
+           |$idt${repositoriesWithEmptyNames.map(repo => Repository.render(propsName, repo).toQuotedString).stringsMkString("  ", s",\n$idt  ", "")}
            |$idt)""".stripMargin.some
       val input = repositories ++ repositoriesWithEmptyNames
       val actual = BuildSbt.renderListOfFieldValue(none[String], propsName, input, n)
@@ -244,8 +244,8 @@ object BuildSbtSpec extends Properties {
       val idt = StringUtils.indent(n)
       val expected =
         s"""resolvers ++= List(
-           |$idt${repositories.map(repo => Repository.render(propsName, repo).toQuotedString).mkString("  ", s",\n$idt  ", ",")}
-           |$idt${repositoriesWithEmptyNames.map(repo => Repository.render(propsName, repo).toQuotedString).mkString("  ", s",\n$idt  ", "")}
+           |$idt${repositories.map(repo => Repository.render(propsName, repo).toQuotedString).stringsMkString("  ", s",\n$idt  ", ",")}
+           |$idt${repositoriesWithEmptyNames.map(repo => Repository.render(propsName, repo).toQuotedString).stringsMkString("  ", s",\n$idt  ", "")}
            |$idt)""".stripMargin.some
       val input = repositories ++ repositoriesWithEmptyNames
       val actual = BuildSbt.renderListOfFieldValue(none[String], propsName, input, n)
@@ -261,8 +261,8 @@ object BuildSbtSpec extends Properties {
       val idt = StringUtils.indent(n)
       val expected =
         s"""resolvers ++= List(
-           |$idt${repositories.map(repo => Repository.render(propsName, repo).toQuotedString).mkString("  ", s",\n$idt  ", ",")}
-           |$idt${repositoriesWithEmptyNames.map(repo => Repository.render(propsName, repo).toQuotedString).mkString("  ", s",\n$idt  ", "")}
+           |$idt${repositories.map(repo => Repository.render(propsName, repo).toQuotedString).stringsMkString("  ", s",\n$idt  ", ",")}
+           |$idt${repositoriesWithEmptyNames.map(repo => Repository.render(propsName, repo).toQuotedString).stringsMkString("  ", s",\n$idt  ", "")}
            |$idt)""".stripMargin.some
       val input = repositories ++ repositoriesWithEmptyNames
       val actual = BuildSbt.renderListOfFieldValue(none[String], propsName, input, n)
@@ -300,7 +300,7 @@ object BuildSbtSpec extends Properties {
       val idt = StringUtils.indent(n)
       val expected =
         s"""libraryDependencies ++= List(
-           |$idt${libraryDependencies.map(dep => Dependency.render(propsName, dep).toQuotedString).mkString("  ", s",\n$idt  ", "")}
+           |$idt${libraryDependencies.map(dep => Dependency.render(propsName, dep).toQuotedString).stringsMkString("  ", s",\n$idt  ", "")}
            |$idt)""".stripMargin.some
       val actual = BuildSbt.renderListOfFieldValue(none[String], propsName, libraryDependencies, n)
       actual ==== expected

--- a/core/src/test/scala/maven2sbt/core/ExclusionSpec.scala
+++ b/core/src/test/scala/maven2sbt/core/ExclusionSpec.scala
@@ -46,7 +46,7 @@ object ExclusionSpec extends Properties {
     val indent = " " * 8
     val expected =
       s""" excludeAll(
-         |$indent  ${exclusions.map(Exclusion.renderExclusionRule(propsName, _).toQuotedString).mkString(s",\n$indent  ")}
+         |$indent  ${exclusions.map(Exclusion.renderExclusionRule(propsName, _).toQuotedString).stringsMkString(s",\n$indent  ")}
          |$indent)""".stripMargin
     val actual = Exclusion.renderExclusions(propsName, exclusions).toQuotedString
     actual ==== expected
@@ -58,7 +58,7 @@ object ExclusionSpec extends Properties {
     val indent = " " * 8
     val expected =
       s""" excludeAll(
-         |$indent  ${exclusions.map(Exclusion.renderExclusionRule(propsName, _).toQuotedString).mkString(s",\n$indent  ")}
+         |$indent  ${exclusions.map(Exclusion.renderExclusionRule(propsName, _).toQuotedString).stringsMkString(s",\n$indent  ")}
          |$indent)""".stripMargin
     val actual = Exclusion.renderExclusions(propsName, exclusions).toQuotedString
     actual ==== expected

--- a/core/src/test/scala/maven2sbt/core/Gens.scala
+++ b/core/src/test/scala/maven2sbt/core/Gens.scala
@@ -36,17 +36,17 @@ object Gens {
   def genRepositoryId: Gen[RepoId] =
     Gen.string(Gen.alphaNum, Range.linear(1, 10))
       .list(Range.linear(1, 5))
-      .map(id => RepoId(id.mkString("-")))
+      .map(id => RepoId(id.stringsMkString("-")))
 
   def genRepositoryName: Gen[RepoName] =
     Gen.string(Gen.alphaNum, Range.linear(1, 10))
       .list(Range.linear(1, 5))
-      .map(name => RepoName(name.mkString(" ")))
+      .map(name => RepoName(name.stringsMkString(" ")))
 
   def genRepositoryUrl: Gen[RepoUrl] =
     Gen.string(Gen.alphaNum, Range.linear(1, 10))
       .list(Range.linear(1, 5))
-      .map(url => RepoUrl(url.mkString("https://", ".", "")))
+      .map(url => RepoUrl(url.stringsMkString("https://", ".", "")))
 
   def genRepository: Gen[Repository] = for {
     id <- genRepositoryId

--- a/core/src/test/scala/maven2sbt/core/PropsSpec.scala
+++ b/core/src/test/scala/maven2sbt/core/PropsSpec.scala
@@ -28,7 +28,7 @@ object PropsSpec extends Properties {
         )
     }.unzip
     val indent = " " * indentSize
-    val expected = propsRendered.mkString(s"lazy val ${propsName.propsName} = new {\n$indent", s"\n$indent", "\n}")
+    val expected = propsRendered.stringsMkString(s"lazy val ${propsName.propsName} = new {\n$indent", s"\n$indent", "\n}")
     val props = input.map(mavenProperty => M2sProp.fromMavenProperty(mavenProperty))
     val actual = Props.renderProps(propsName, indentSize, props)
     actual ==== expected


### PR DESCRIPTION
Added: `stringsMkString` to replace `mkString` to make sure `Seq[A]` is `Seq[String]` when `mkString`