### PR TITLE
maven2sbt v1.1.0

### DIFF
--- a/changelogs/1.1.0.md
+++ b/changelogs/1.1.0.md
@@ -1,0 +1,12 @@
+## [1.1.0](https://github.com/Kevin-Lee/maven2sbt/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+milestone%3Amilestone6) - 2020-12-29
+
+### Done
+* Add props name param (`--props-name`) (#167)
+
+### Fixed
+* Fix - possible reserved sbt words used as property names (e.g. `scalaVersion`, `version`, etc.) (#147)
+* Fixed missing id and name handling for a repository (#148)
+* Fix - Handle properties in properties, dependencies and repositories properly (#149)
+* `ExclusionRule` is set with the incorrect named parameter (#158)
+* String interpolation is broken (#168)
+* Some `String` values are not rendered with props properly (#170)

--- a/project/SbtProjectInfo.scala
+++ b/project/SbtProjectInfo.scala
@@ -3,13 +3,12 @@ import wartremover.WartRemover.autoImport.{Wart, Warts}
 object SbtProjectInfo {
   final case class ProjectName(projectName: String) extends AnyVal
 
-  val ProjectVersion: String = "1.0.0"
+  val ProjectVersion: String = "1.1.0"
 
   def commonWarts(scalaBinaryVersion: String): Seq[wartremover.Wart] = scalaBinaryVersion match {
     case "2.10" =>
       Seq.empty
     case _ =>
-//      Warts.all
       Warts.allBut(Wart.ImplicitConversion, Wart.ImplicitParameter)
   }
 


### PR DESCRIPTION
# maven2sbt v1.1.0
## [1.1.0](https://github.com/Kevin-Lee/maven2sbt/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+milestone%3Amilestone6) - 2020-12-29

### Done
* Add props name param (`--props-name`) (#167)

### Fixed
* Fix - possible reserved sbt words used as property names (e.g. `scalaVersion`, `version`, etc.) (#147)
* Fixed missing id and name handling for a repository (#148)
* Fix - Handle properties in properties, dependencies and repositories properly (#149)
* `ExclusionRule` is set with the incorrect named parameter (#158)
* String interpolation is broken (#168)
* Some `String` values are not rendered with props properly (#170)
