### PR TITLE
Close #197 - Support getting groupId from <parent> element if no groupId is found in pom.xml

### DIFF
--- a/core/src/main/scala/maven2sbt/core/BuildSbt.scala
+++ b/core/src/main/scala/maven2sbt/core/BuildSbt.scala
@@ -135,8 +135,7 @@ object BuildSbt {
       val thisBuildSettingsRendered = ThisBuildSettings.render(propsName, libsName, thisBuildSettings)
       val projectSettingsRendered = ProjectSettings.render(propsName, libsName, libs, projectSettings)
 
-      s"""
-         |$globalSettingsRendered
+      s"""$globalSettingsRendered
          |$thisBuildSettingsRendered
          |lazy val root = (project in file("."))
          |  .settings(

--- a/core/src/main/scala/maven2sbt/core/ProjectInfo.scala
+++ b/core/src/main/scala/maven2sbt/core/ProjectInfo.scala
@@ -1,5 +1,7 @@
 package maven2sbt.core
 
+import cats.Show
+
 import scala.language.postfixOps
 import scala.xml.Elem
 
@@ -16,10 +18,20 @@ final case class ProjectInfo(
 object ProjectInfo {
 
   def from(pom: Elem): ProjectInfo = {
-    val groupId = GroupId(pom \ "groupId" text)
+    val groupIdStr = (pom \ "groupId").text
+    val groupId =
+      if (groupIdStr.isBlank)
+        GroupId((pom \ "parent" \ "groupId").text)
+      else
+        GroupId(groupIdStr)
     val artifactId = ArtifactId(pom \ "artifactId" text)
     val version = Version(pom \ "version" text)
     ProjectInfo(groupId, artifactId, version)
   }
 
+  implicit val show: Show[ProjectInfo] =
+    projectInfo =>
+      s"ProjectInfo(groupId: ${projectInfo.groupId.groupId}, " +
+        s"artifactId: ${projectInfo.artifactId.artifactId}, " +
+        s"version: ${projectInfo.version.version})"
 }


### PR DESCRIPTION
Close #197 - Support getting `groupId` from `<parent>` element if no `groupId` is found in `pom.xml`