### PR TITLE
maven2sbt v1.2.0

### DIFF
--- a/.scripts/install.sh
+++ b/.scripts/install.sh
@@ -4,7 +4,7 @@ set -eu
 
 app_executable_name=maven2sbt
 app_name=maven2sbt-cli
-app_version=${1:-1.1.1}
+app_version=${1:-1.2.0}
 versioned_app_name="${app_name}-${app_version}"
 app_zip_file="${versioned_app_name}.zip"
 download_url="https://github.com/Kevin-Lee/maven2sbt/releases/download/v${app_version}/${app_zip_file}"

--- a/changelogs/1.2.0.md
+++ b/changelogs/1.2.0.md
@@ -1,0 +1,9 @@
+## [1.2.0](https://github.com/Kevin-Lee/maven2sbt/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+milestone%3Amilestone8) - 2021-03-09
+
+### Done
+* Add support Maven's `<dependencyManagement>` (#185)
+* Support Scala dependency with `scalaBinaryVersion` (#187)
+* Use `libs` for `libraryDependencies` when it's found in `libs` (#190)
+* Add `libs` name param (`--libs-name`) (#191)
+* Add Scala binary version param (`--scala-binary-version-name` | `-b`) (#192)
+* Support getting `groupId` from `<parent>` element if no `groupId` is found in `pom.xml` (#197)

--- a/project/SbtProjectInfo.scala
+++ b/project/SbtProjectInfo.scala
@@ -3,7 +3,7 @@ import wartremover.WartRemover.autoImport.{Wart, Warts}
 object SbtProjectInfo {
   final case class ProjectName(projectName: String) extends AnyVal
 
-  val ProjectVersion: String = "1.1.1"
+  val ProjectVersion: String = "1.2.0"
 
   def commonWarts(scalaBinaryVersion: String): Seq[wartremover.Wart] = scalaBinaryVersion match {
     case "2.10" =>


### PR DESCRIPTION
# maven2sbt v1.2.0
## [1.2.0](https://github.com/Kevin-Lee/maven2sbt/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+milestone%3Amilestone8) - 2021-03-09

### Done
* Add support Maven's `<dependencyManagement>` (#185)
* Support Scala dependency with `scalaBinaryVersion` (#187)
* Use `libs` for `libraryDependencies` when it's found in `libs` (#190)
* Add `libs` name param (`--libs-name`) (#191)
* Add Scala binary version param (`--scala-binary-version-name` | `-b`) (#192)
* Support getting `groupId` from `<parent>` element if no `groupId` is found in `pom.xml` (#197)
