### PR TITLE
Close #238 - Increase the column length of help descriptions from 80 to 100

### DIFF
--- a/cli/src/main/scala/maven2sbt/cli/MainIo.scala
+++ b/cli/src/main/scala/maven2sbt/cli/MainIo.scala
@@ -19,7 +19,7 @@ trait MainIo[A] extends IOApp {
 
   def runApp(args: A): IO[Either[Maven2SbtError, Unit]]
 
-  def prefs: Prefs = DefaultPrefs()
+  def prefs: Prefs = DefaultPrefs().copy(descIndent = 33, width = 100)
 
   def exitWith[X](exitCode: ExitCode): IO[X] =
     IO(sys.exit(exitCode.code))


### PR DESCRIPTION
Close #238 - Increase the column length of help descriptions from `80` to `100`