### PR TITLE
maven2sbt v1.3.0

### DIFF
--- a/changelogs/1.3.0.md
+++ b/changelogs/1.3.0.md
@@ -1,0 +1,12 @@
+## [1.3.0](https://github.com/Kevin-Lee/maven2sbt/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+milestone%3Amilestone9) - 2021-03-24
+
+### Done
+* Support Scala `3.0.0-RC1` (#208)
+* Build with GraalVM (#214)
+* Release GraalVM Native Image for macOS and Linux (#218)
+* Add installation script for GraalVM Native Image for macOS (#223)
+* Add installation script for GraalVM Native Image for Ubuntu and Debian Linux (#225)
+* Change GitHub Actions for better GraalVM support (#227)
+* Add GraalVM Native Image build for Windows (#229)
+* Increase the column length of help descriptions from `80` to `100` (#238)
+* Stop uploading the jar files, the Debian package and the tarball file to GitHub Release (#240)

--- a/project/SbtProjectInfo.scala
+++ b/project/SbtProjectInfo.scala
@@ -3,7 +3,7 @@ import wartremover.WartRemover.autoImport.{Wart, Warts}
 object SbtProjectInfo {
   final case class ProjectName(projectName: String) extends AnyVal
 
-  val ProjectVersion: String = "1.2.0"
+  val ProjectVersion: String = "1.3.0"
 
   def commonWarts(scalaBinaryVersion: String): Seq[wartremover.Wart] = scalaBinaryVersion match {
     case "2.10" =>


### PR DESCRIPTION
# maven2sbt v1.3.0
## [1.3.0](https://github.com/Kevin-Lee/maven2sbt/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+milestone%3Amilestone9) - 2021-03-24

### Done
* Support Scala `3.0.0-RC1` (#208)
* Build with GraalVM (#214)
* Release GraalVM Native Image for macOS and Linux (#218)
* Add installation script for GraalVM Native Image for macOS (#223)
* Add installation script for GraalVM Native Image for Ubuntu and Debian Linux (#225)
* Change GitHub Actions for better GraalVM support (#227)
* Add GraalVM Native Image build for Windows (#229)
* Increase the column length of help descriptions from `80` to `100` (#238)
* Stop uploading the jar files, the Debian package and the tarball file to GitHub Release (#240)
