### PR TITLE
maven2sbt v1.4.0

### DIFF
--- a/changelogs/1.4.0.md
+++ b/changelogs/1.4.0.md
@@ -1,0 +1,6 @@
+## [1.4.0](https://github.com/Kevin-Lee/maven2sbt/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+milestone%3Amilestone10) - 2021-06-09
+
+### Done
+* Support Scala `3.0.0` (#262)
+* Publish directly to Maven Central (#254)
+* ~~Support Scala `3.0.0-RC2` and Scala `3.0.0-RC3`~~ (#249)


### PR DESCRIPTION
# maven2sbt v1.4.0
## [1.4.0](https://github.com/Kevin-Lee/maven2sbt/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+milestone%3Amilestone10) - 2021-06-09

### Done
* Support Scala `3.0.0` (#262)
* Publish directly to Maven Central (#254)
* ~~Support Scala `3.0.0-RC2` and Scala `3.0.0-RC3`~~ (#249)
