### PR TITLE
Fix #298 - Clean installation fails when `usr_local_bin_path` does not exist

### DIFF
--- a/.scripts/install-graal-macos.sh
+++ b/.scripts/install-graal-macos.sh
@@ -39,6 +39,7 @@ rm -R $app_location || true
 mkdir -p $app_location
 mv $app_package_file $installed_app_bin_path
 
+mkdir -p $usr_local_bin_path
 echo ""
 { rm $app_bin_path && { echo "The existing $app_bin_path was found so it was removed." ; } } || { echo "No existing $app_bin_path was found. It's OK. Please ignore the 'No such file or directory' message." ; }
 echo ""

--- a/.scripts/install-graal-ubuntu.sh
+++ b/.scripts/install-graal-ubuntu.sh
@@ -39,6 +39,7 @@ rm -R $app_location || true
 mkdir -p $app_location
 mv $app_package_file $installed_app_bin_path
 
+mkdir -p $usr_local_bin_path
 echo ""
 { rm $app_bin_path && { echo "The existing $app_bin_path was found so it was removed." ; } } || { echo "No existing $app_bin_path was found. It's OK. Please ignore the 'No such file or directory' message." ; }
 echo ""

--- a/.scripts/install.sh
+++ b/.scripts/install.sh
@@ -40,6 +40,7 @@ mkdir -p $opt_location
 rm -R $app_location || true
 mv $versioned_app_name $app_location
 
+mkdir -p $usr_local_bin_path
 echo ""
 { rm $app_bin_path && { echo "The existing $app_bin_path was found so it was removed." ; } } || { echo "No existing $app_bin_path was found. It's OK. Please ignore the 'No such file or directory' message." ; }
 echo ""


### PR DESCRIPTION
Fix #298 - Clean installation fails when `usr_local_bin_path` does not exist