### PR TITLE
Bump Scala and libraries

### DIFF
--- a/.github/workflows/build-graal.yml
+++ b/.github/workflows/build-graal.yml
@@ -10,7 +10,7 @@ on:
       - main
 
 env:
-  CLI_SCALA_VERSION: "3.1.2"
+  CLI_SCALA_VERSION: "3.2.1"
   CLI_SCALA_BINARY_VERSION: "3"
   GRAALVM_JAVA_VERSION: "adopt@1.11"
   GRAALVM_BIN_DIR_NAME: "native-image"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
         scala:
           - { name: "Scala 2", version: "2.12.17", binary-version: "2.12", java-version: "adopt@1.11", report: "" }
           - { name: "Scala 2", version: "2.13.10", binary-version: "2.13", java-version: "adopt@1.11", report: "report" }
-          - { name: "Scala 3", version: "3.1.2",   binary-version: "3",    java-version: "adopt@1.11", report: "" }
+          - { name: "Scala 3", version: "3.2.1",   binary-version: "3",    java-version: "adopt@1.11", report: "" }
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ on:
 
 env:
   GH_JAVA_VERSION: "adopt@1.11"
-  CLI_SCALA_VERSION: "3.1.2"
+  CLI_SCALA_VERSION: "3.2.1"
   CLI_SCALA_BINARY_VERSION: "3"
   GRAALVM_JAVA_VERSION: "adopt@1.11"
   GRAALVM_BIN_DIR_NAME: "native-image"

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,4 +1,4 @@
-version = 3.5.1
+version = 3.6.1
 runner.dialect = scala3
 
 //align.preset=more

--- a/build.sbt
+++ b/build.sbt
@@ -46,17 +46,16 @@ lazy val core = subProject("core")
     libraryDependencies ++= {
       val scalaV = scalaVersion.value
       if (scalaV.startsWith("3"))
-        List(libs.catsLib, libs.scalaXmlLatest)
-      else if (scalaV.startsWith("2.11"))
-        List(libs.newTypeLib, libs.cats_2_0_0, libs.scalaXml)
+        List(libs.catsLib, libs.scalaXml)
       else
-        List(libs.newTypeLib, libs.catsLib, libs.scalaXmlLatest)
+        List(libs.newTypeLib, libs.catsLib, libs.scalaXml)
     },
     libraryDependencies ++= List(
       libs.effectieCore,
       libs.effectieSyntax,
       libs.effectieCatsEffect2,
       libs.extrasCats,
+      libs.extrasScalaIo,
     ),
     libraryDependencies := libraryDependenciesPostProcess(scalaVersion.value, libraryDependencies.value),
     wartremoverExcluded ++= List(sourceManaged.value),
@@ -118,53 +117,53 @@ lazy val props =
     val ExecutableScriptName = RepoName
 
     val Scala2Version       = "2.13.10"
-    val DottyVersion        = "3.1.2"
+    val DottyVersion        = "3.2.1"
     val CrossScalaVersions  = List("2.12.17", Scala2Version, DottyVersion).distinct
     val ProjectScalaVersion = Scala2Version
 
-    val hedgehogVersion = "0.9.0"
+    val CatsVersion       = "2.9.0"
+    val CatsEffectVersion = "3.4.3"
+
+    val HedgehogVersion = "0.10.1"
 
 //    val canEqualVersion = "0.1.0"
 
-    val EffectieVersion = "2.0.0-beta2"
-    val LoggerFVersion  = "2.0.0-beta2"
+    val EffectieVersion = "2.0.0-beta4"
+    val LoggerFVersion  = "2.0.0-beta4"
 
-    val pirateVersion = "4e8177ec1548780cbf62b0352e58bceb7a99bfd6"
-    val pirateUri     = uri(s"https://github.com/$GitHubUsername/pirate.git#$pirateVersion")
+    val PirateVersion = "7797fb3884bdfdda7751d8f75accf622b30a53ed"
+    val pirateUri     = uri(s"https://github.com/$GitHubUsername/pirate.git#$PirateVersion")
 
-    val scalaXml1 = "1.3.0"
-    val scalaXml2 = "2.1.0"
+    val ScalaXml2Version = "2.1.0"
 
-    val ExtrasVersion = "0.20.0"
+    val ExtrasVersion = "0.26.0"
 
   }
 
 lazy val libs =
   new {
     lazy val hedgehogLibs: List[ModuleID] = List(
-      "qa.hedgehog" %% "hedgehog-core"   % props.hedgehogVersion % Test,
-      "qa.hedgehog" %% "hedgehog-runner" % props.hedgehogVersion % Test,
-      "qa.hedgehog" %% "hedgehog-sbt"    % props.hedgehogVersion % Test,
+      "qa.hedgehog" %% "hedgehog-core"   % props.HedgehogVersion % Test,
+      "qa.hedgehog" %% "hedgehog-runner" % props.HedgehogVersion % Test,
+      "qa.hedgehog" %% "hedgehog-sbt"    % props.HedgehogVersion % Test,
     )
 
 //    lazy val canEqual = "io.kevinlee" %% "can-equal" % props.canEqualVersion
 
-    lazy val scalaXmlLatest = "org.scala-lang.modules" %% "scala-xml" % props.scalaXml2
-    lazy val scalaXml       = "org.scala-lang.modules" %% "scala-xml" % props.scalaXml1
+    lazy val scalaXml = "org.scala-lang.modules" %% "scala-xml" % props.ScalaXml2Version
 
-    lazy val catsLib    = "org.typelevel" %% "cats-core" % "2.8.0"
-    lazy val cats_2_0_0 = "org.typelevel" %% "cats-core" % "2.0.0"
+    lazy val catsLib = "org.typelevel" %% "cats-core" % props.CatsVersion
 
-    lazy val catsEffectLib    = "org.typelevel" %% "cats-effect" % "2.5.5"
-    lazy val catsEffect_2_0_0 = "org.typelevel" %% "cats-effect" % "2.0.0"
+    lazy val catsEffectLib = "org.typelevel" %% "cats-effect" % props.CatsEffectVersion
 
     lazy val effectieCore        = "io.kevinlee" %% "effectie-core"         % props.EffectieVersion
     lazy val effectieSyntax      = "io.kevinlee" %% "effectie-syntax"       % props.EffectieVersion
-    lazy val effectieCatsEffect2 = "io.kevinlee" %% "effectie-cats-effect2" % props.EffectieVersion
+    lazy val effectieCatsEffect2 = "io.kevinlee" %% "effectie-cats-effect3" % props.EffectieVersion
 
     lazy val newTypeLib = "io.estatico" %% "newtype" % "0.4.4"
 
-    lazy val extrasCats = "io.kevinlee" %% "extras-cats" % props.ExtrasVersion
+    lazy val extrasCats    = "io.kevinlee" %% "extras-cats"     % props.ExtrasVersion
+    lazy val extrasScalaIo = "io.kevinlee" %% "extras-scala-io" % props.ExtrasVersion
   }
 
 def libraryDependenciesPostProcess(

--- a/modules/maven2sbt-cli/src/main/scala/maven2sbt/cli/MainIo.scala
+++ b/modules/maven2sbt-cli/src/main/scala/maven2sbt/cli/MainIo.scala
@@ -2,8 +2,8 @@ package maven2sbt.cli
 
 import cats.effect.*
 import effectie.core.ConsoleEffect
-import effectie.ce2.fx.ioFx
-import effectie.syntax.all.consoleEffectF
+import effectie.instances.ce3.fx.ioFx
+import effectie.instances.console.consoleEffectF
 import maven2sbt.core.Maven2SbtError
 import pirate.{ExitCode as PirateExitCode, *}
 import scalaz.*

--- a/modules/maven2sbt-cli/src/main/scala/maven2sbt/cli/Maven2SbtApp.scala
+++ b/modules/maven2sbt-cli/src/main/scala/maven2sbt/cli/Maven2SbtApp.scala
@@ -3,8 +3,8 @@ package maven2sbt.cli
 import cats.effect.*
 import cats.syntax.all.*
 import effectie.core.*
-import effectie.ce2.fx.ioFx
-import effectie.syntax.console.consoleEffectF
+import effectie.instances.ce3.fx.ioFx
+import effectie.instances.console.consoleEffectF
 import extras.cats.syntax.all.*
 import maven2sbt.core.{BuildSbt, Maven2Sbt, Maven2SbtError}
 import pirate.*

--- a/modules/maven2sbt-cli/src/main/scala/maven2sbt/cli/Maven2SbtApp.scala
+++ b/modules/maven2sbt-cli/src/main/scala/maven2sbt/cli/Maven2SbtApp.scala
@@ -2,7 +2,6 @@ package maven2sbt.cli
 
 import cats.effect.*
 import cats.syntax.all.*
-import effectie.core.*
 import effectie.instances.ce3.fx.ioFx
 import effectie.instances.console.consoleEffectF
 import extras.cats.syntax.all.*
@@ -27,10 +26,12 @@ object Maven2SbtApp extends MainIo[Maven2SbtArgs] {
 
   override def command: Command[Maven2SbtArgs] = cmd
 
+  override def prefs: Prefs = DefaultPrefs().copy(width = 100)
+
   def toCanonicalFile(file: File): File =
     if (file.isAbsolute) file else file.getCanonicalFile
 
-  override def runApp(args: Maven2SbtArgs): IO[Either[Maven2SbtError, Unit]] = args match {
+  override def runApp(args: Maven2SbtArgs): IO[Either[Maven2SbtError, Option[String]]] = args match {
     case Maven2SbtArgs.FileArgs(scalaVersion, scalaBinaryVersionName, propsName, libsName, out, overwrite, pomPath) =>
       for {
         pom          <- IO(toCanonicalFile(pomPath))
@@ -38,7 +39,7 @@ object Maven2SbtApp extends MainIo[Maven2SbtArgs] {
         result       <-
           (buildSbtPath.exists, overwrite) match {
             case (true, Overwrite.DoNotOverwrite) =>
-              IO(Maven2SbtError.outputFileAlreadyExist(buildSbtPath).asLeft)
+              IO(Maven2SbtError.outputFileAlreadyExist(buildSbtPath).asLeft[Option[String]])
 
             case (false, Overwrite.DoNotOverwrite) | (_, Overwrite.DoOverwrite) =>
               IO(new BufferedWriter(new FileWriter(buildSbtPath)))
@@ -53,16 +54,13 @@ object Maven2SbtApp extends MainIo[Maven2SbtArgs] {
                                         )
                                         .eitherT
                     buildSbtString <- IO(BuildSbt.render(buildSbt, propsName, libsName)).rightT
-                    _              <- IO(writer.write(buildSbtString)).rightT
-                    _              <- ConsoleEffect[IO]
-                                        .putStrLn(
-                                          s"""Success] The sbt config file has been successfully written at
+                    _              <- IO(writer.write(buildSbtString)).rightT[Maven2SbtError]
+                    result =
+                      s"""Success] The sbt config file has been successfully written at
                                              |  ${buildSbtPath.getCanonicalPath}
                                              |""".stripMargin
-                                        )
-                                        .rightTF[IO, Maven2SbtError]
 
-                  } yield ()).value
+                  } yield result.some).value
                 }(writer => IO(writer.close()))
           }
       } yield result
@@ -71,10 +69,9 @@ object Maven2SbtApp extends MainIo[Maven2SbtArgs] {
       (for {
         pom            <- IO(toCanonicalFile(pomPath)).rightT
         buildSbt       <- maven2SbtIo.buildSbtFromPomFile(scalaVersion, propsName, scalaBinaryVersionName, pom).eitherT
-        buildSbtString <- IO(BuildSbt.render(buildSbt, propsName, libsName)).rightT
-        _              <- ConsoleEffect[IO].putStrLn(buildSbtString).rightT[Maven2SbtError]
+        buildSbtString <- IO(BuildSbt.render(buildSbt, propsName, libsName)).rightT[Maven2SbtError]
 
-      } yield ()).value
+      } yield buildSbtString.some).value
   }
 
 }

--- a/modules/maven2sbt-cli/src/main/scala/maven2sbt/cli/Maven2SbtArgsParser.scala
+++ b/modules/maven2sbt-cli/src/main/scala/maven2sbt/cli/Maven2SbtArgsParser.scala
@@ -4,6 +4,7 @@ import scalaz.*
 import Scalaz.*
 import pirate.*
 import Pirate.*
+import cats.Show
 import maven2sbt.core.{Libs, Props, ScalaBinaryVersion, ScalaVersion}
 import maven2sbt.info.Maven2SbtBuildInfo
 
@@ -112,5 +113,22 @@ object Maven2SbtArgsParser {
         )
       )) <* version(Maven2SbtBuildInfo.version)
     )
+
+  sealed trait ArgParseFailureResult
+  object ArgParseFailureResult {
+    final case class JustMessageOrHelp(messages: List[String]) extends ArgParseFailureResult
+    object JustMessageOrHelp {
+      implicit val justMessageOrHelpShow: Show[JustMessageOrHelp] = Show.show(_.messages.mkString("\n"))
+    }
+
+    final case class ArgParseError(errors: List[String]) extends ArgParseFailureResult
+    object ArgParseError {
+      implicit val argParseErrorShow: Show[ArgParseError] = Show.show(_.errors.mkString("\n"))
+    }
+
+    def justMessageOrHelp(messages: List[String]): ArgParseFailureResult = JustMessageOrHelp(messages)
+    def argParseError(errors: List[String]): ArgParseFailureResult       = ArgParseError(errors)
+
+  }
 
 }

--- a/modules/maven2sbt-core/src/main/scala/maven2sbt/core/Maven2SbtError.scala
+++ b/modules/maven2sbt-core/src/main/scala/maven2sbt/core/Maven2SbtError.scala
@@ -1,5 +1,8 @@
 package maven2sbt.core
 
+import cats.syntax.all.*
+import extras.scala.io.syntax.color.*
+
 import java.io.File
 
 /** @author Kevin Lee
@@ -13,9 +16,13 @@ object Maven2SbtError {
   case object NoPomInputStream extends Maven2SbtError
   final case class OutputFileAlreadyExist(output: File) extends Maven2SbtError
 
+  final case class ArgParse(errors: List[String]) extends Maven2SbtError
+
   def pomFileNotExist(pomFile: File): Maven2SbtError       = PomFileNotExist(pomFile)
   def noPomInputStream: Maven2SbtError                     = NoPomInputStream
   def outputFileAlreadyExist(output: File): Maven2SbtError = OutputFileAlreadyExist(output)
+
+  def argParse(errors: List[String]): Maven2SbtError = ArgParse(errors)
 
   def render(maven2SbtError: Maven2SbtError): String = maven2SbtError match {
     case PomFileNotExist(pomFile) =>
@@ -26,6 +33,12 @@ object Maven2SbtError {
 
     case OutputFileAlreadyExist(output) =>
       s"Output file already exists at ${output.getCanonicalPath}"
+
+    case ArgParse(errors) =>
+      s""">> ${"CLI arguments error".red}:
+         |>> ${errors.mkString_("\n")}
+         |""".stripMargin
+
   }
 
 }


### PR DESCRIPTION
Bump Scala and libraries
- scala 3.1.2 => 3.2.1
- cats 2.8.0 => 2.9.0
- cats-effect 2.5.5 => 3.4.3
- hedgehog 0.9.0 => 0.10.1
- effectie 2.0.0-beta2 => 2.0.0-beta4
- logger-f 2.0.0-beta2 => 2.0.0-beta4
- pirate 4e8177ec1548780cbf62b0352e58bceb7a99bfd6 => 7797fb3884bdfdda7751d8f75accf622b30a53ed
- extras 0.20.0 => 0.26.0
- scalafmt 3.5.1 => 3.6.1