### PR TITLE
Close #318 - Upgrade cats-effect to 3.4.4

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -122,7 +122,7 @@ lazy val props =
     val ProjectScalaVersion = Scala2Version
 
     val CatsVersion       = "2.9.0"
-    val CatsEffectVersion = "3.4.3"
+    val CatsEffectVersion = "3.4.4"
 
     val HedgehogVersion = "0.10.1"
 


### PR DESCRIPTION
Close #318 - Upgrade cats-effect to `3.4.4`
- cats-effect `3.4.4` fixes a memory leak in Deferred