### PR TITLE
Fix #330 - Property should not take `#REM` from Maven properties

### DIFF
--- a/modules/maven2sbt-core/src/main/scala/maven2sbt/core/MavenPropertyPlus.scala
+++ b/modules/maven2sbt-core/src/main/scala/maven2sbt/core/MavenPropertyPlus.scala
@@ -14,7 +14,7 @@ trait MavenPropertyPlus {
     properties <- pom \ "properties"
     property   <- properties.child
     label = property.label
-    if !label.startsWith("#PCDATA")
+    if !label.startsWith("#")
   } yield MavenProperty(Name(label), Value(property.text))
 
   def findPropertyName(name: String): Option[String] = name match {

--- a/modules/maven2sbt-core/src/test/scala/maven2sbt/core/MavenPropertySpec.scala
+++ b/modules/maven2sbt-core/src/test/scala/maven2sbt/core/MavenPropertySpec.scala
@@ -17,12 +17,14 @@ object MavenPropertySpec extends Properties {
     else
       <project>
         <properties>
+          <!-- blah -->
           {
         properties.map {
           case MavenProperty(key, value) =>
             Elem(null, key.value, Null, TopScope, true, Text(value.value)) // scalafix:ok DisableSyntax.null
         }
       }
+          <!-- blah -->
         </properties>
       </project>
 


### PR DESCRIPTION
Fix #330 - Property should not take `#REM` from Maven properties