### PR TITLE
Close #334 - Upgrade libraries: cats-effect, effectie, logger-f and extras

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -125,21 +125,21 @@ lazy val props =
     val ProjectScalaVersion = Scala2Version
 
     val CatsVersion       = "2.9.0"
-    val CatsEffectVersion = "3.4.7"
+    val CatsEffectVersion = "3.4.8"
 
     val HedgehogVersion = "0.10.1"
 
 //    val canEqualVersion = "0.1.0"
 
-    val EffectieVersion = "2.0.0-beta6"
-    val LoggerFVersion  = "2.0.0-beta9"
+    val EffectieVersion = "2.0.0-beta9"
+    val LoggerFVersion  = "2.0.0-beta12"
 
     val PirateVersion = "7797fb3884bdfdda7751d8f75accf622b30a53ed"
     val pirateUri     = uri(s"https://github.com/$GitHubUsername/pirate.git#$PirateVersion")
 
     val ScalaXml2Version = "2.1.0"
 
-    val ExtrasVersion = "0.31.0"
+    val ExtrasVersion = "0.38.0"
 
   }
 

--- a/modules/maven2sbt-cli/src/main/scala/maven2sbt/cli/MainIo.scala
+++ b/modules/maven2sbt-cli/src/main/scala/maven2sbt/cli/MainIo.scala
@@ -2,9 +2,8 @@ package maven2sbt.cli
 
 import cats.effect.*
 import cats.syntax.all.*
-import effectie.core.ConsoleEffect
+import effectie.core.ConsoleFx
 import effectie.instances.ce3.fx.ioFx
-import effectie.instances.console.consoleEffectF
 import maven2sbt.cli.Maven2SbtArgsParser.ArgParseFailureResult
 import maven2sbt.core.Maven2SbtError
 import pirate.{Command, Prefs}
@@ -59,10 +58,9 @@ trait MainIo[A] extends IOApp {
       errorOrResult <- codeOrA.fold(exitCodeToEither, runApp)
       exitCode      <- errorOrResult.fold(
                          err =>
-                           ConsoleEffect[IO].putErrStrLn(Maven2SbtError.render(err)) *>
+                           ConsoleFx[IO].putErrStrLn(Maven2SbtError.render(err)) *>
                              IO.pure(ExitCode.Error),
-                         _.fold(IO.pure(ExitCode.Success))(msg =>
-                           ConsoleEffect[IO].putStrLn(msg) *> IO.pure(ExitCode.Success),
+                         _.fold(IO.pure(ExitCode.Success))(msg => ConsoleFx[IO].putStrLn(msg) *> IO.pure(ExitCode.Success),
                          ),
                        )
     } yield exitCode


### PR DESCRIPTION
Close #334 - Upgrade libraries: cats-effect, effectie, logger-f and extras
* cats-effect to 3.4.8
* effectie to 2.0.0-beta9
* logger-f to 2.0.0-beta12
* extras to 0.38.0