### PR TITLE
Bump sbt to 1.9.1 and update build.sbt - remove testFrameworks setup for hedgehog as it's now one of the supported default test frameworks

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -211,7 +211,6 @@ def module(projectName: String): Project = {
   Project(projectName, file(s"modules/$prefixedName"))
     .settings(
       name := prefixedName,
-      testFrameworks ++= Seq(TestFramework("hedgehog.sbt.Framework")),
       libraryDependencies ++= libs.hedgehogLibs,
       scalacOptions := scalacOptionsPostProcess(scalaVersion.value, scalacOptions.value).distinct,
       scalafixConfig := (

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.8.3
+sbt.version=1.9.1


### PR DESCRIPTION
Bump sbt to `1.9.1` and update `build.sbt` - remove `testFrameworks` setup for hedgehog as it's now one of the supported default test frameworks