### PR TITLE
Fix #339 - Update Scope handling including scope from props

### DIFF
--- a/modules/maven2sbt-core/src/main/scala/maven2sbt/core/DependencyPlus.scala
+++ b/modules/maven2sbt-core/src/main/scala/maven2sbt/core/DependencyPlus.scala
@@ -96,7 +96,7 @@ trait DependencyPlus { self =>
               GroupId(groupId),
               ArtifactId(artifactId.substring(0, artifactId.length - suffix.length)),
               Version(version),
-              Option(scope).fold(Scope.default)(Scope.parseUnsafe),
+              Option(scope).fold(Scope.default)(Scope.parse),
               exclusions,
             )
           } else {
@@ -104,7 +104,7 @@ trait DependencyPlus { self =>
               GroupId(groupId),
               ArtifactId(artifactId),
               Version(version),
-              Option(scope).fold(Scope.default)(Scope.parseUnsafe),
+              Option(scope).fold(Scope.default)(Scope.parse),
               exclusions,
             )
           }
@@ -113,7 +113,7 @@ trait DependencyPlus { self =>
             GroupId(groupId),
             ArtifactId(artifactId),
             Version(version),
-            Option(scope).fold(Scope.default)(Scope.parseUnsafe),
+            Option(scope).fold(Scope.default)(Scope.parse),
             exclusions,
           )
 
@@ -136,7 +136,7 @@ trait DependencyPlus { self =>
           val versionStr    = version.render(propsName).toQuotedString
           RenderedString.noQuotesRequired(
             s"""$groupIdStr %% $artifactIdStr % $versionStr${Scope
-                .renderNonCompileWithPrefix(" % ", scope)}${Render[List[Exclusion]]
+                .renderNonCompileWithPrefix(" % ", scope, propsName)}${Render[List[Exclusion]]
                 .render(propsName, exclusions)
                 .toQuotedString}""",
           )
@@ -148,7 +148,7 @@ trait DependencyPlus { self =>
           val versionStr    = version.render(propsName).toQuotedString
           RenderedString.noQuotesRequired(
             s"""$groupIdStr % $artifactIdStr % $versionStr${Scope
-                .renderNonCompileWithPrefix(" % ", scope)}${Render[List[Exclusion]]
+                .renderNonCompileWithPrefix(" % ", scope, propsName)}${Render[List[Exclusion]]
                 .render(propsName, exclusions)
                 .toQuotedString}""",
           )
@@ -168,7 +168,7 @@ trait DependencyPlus { self =>
                 (_, _, libVersion, Scope.Compile | Scope.Default, libExclusions),
                 (_, _, version, scope, exclusions),
               ) if version.value.isBlank || libVersion === version =>
-            if ((scope === Scope.Compile || scope === Scope.Default)) {
+            if (scope === Scope.Compile || scope === Scope.Default) {
               if (libExclusions.length === exclusions.length && libExclusions.diff(exclusions).isEmpty)
                 RenderedString.noQuotesRequired(s"${libsName.value}.${libValName.value}")
               else if (libExclusions.isEmpty)
@@ -180,12 +180,12 @@ trait DependencyPlus { self =>
             } else {
               if (libExclusions.length === exclusions.length && libExclusions.diff(exclusions).isEmpty)
                 RenderedString.noQuotesRequired(
-                  s"""${libsName.value}.${libValName.value}${Scope.renderNonCompileWithPrefix(" % ", scope)}""",
+                  s"""${libsName.value}.${libValName.value}${Scope.renderNonCompileWithPrefix(" % ", scope, propsName)}""",
                 )
               else if (libExclusions.isEmpty)
                 RenderedString.noQuotesRequired(
                   s"${libsName.value}.${libValName.value}${Scope
-                      .renderNonCompileWithPrefix(" % ", scope)}${Render[List[Exclusion]].render(propsName, exclusions).toQuotedString}",
+                      .renderNonCompileWithPrefix(" % ", scope, propsName)}${Render[List[Exclusion]].render(propsName, exclusions).toQuotedString}",
                 )
               else
                 renderWithoutLibs(propsName, dependency)

--- a/modules/maven2sbt-core/src/main/scala/maven2sbt/core/LibsPlus.scala
+++ b/modules/maven2sbt-core/src/main/scala/maven2sbt/core/LibsPlus.scala
@@ -59,7 +59,7 @@ trait LibsPlus {
         libValName,
         RenderedString.noQuotesRequired(
           s"""$groupIdStr %% $artifactIdStr % $versionStr${Scope
-              .renderNonCompileWithPrefix(" % ", scope)}${Render[List[Exclusion]]
+              .renderNonCompileWithPrefix(" % ", scope, propsName)}${Render[List[Exclusion]]
               .render(propsName, exclusions)
               .toQuotedString}""",
         ),
@@ -72,7 +72,7 @@ trait LibsPlus {
         libValName,
         RenderedString.noQuotesRequired(
           s"""$groupIdStr % $artifactIdStr % $versionStr${Scope
-              .renderNonCompileWithPrefix(" % ", scope)}${Render[List[Exclusion]]
+              .renderNonCompileWithPrefix(" % ", scope, propsName)}${Render[List[Exclusion]]
               .render(propsName, exclusions)
               .toQuotedString}""",
         ),

--- a/modules/maven2sbt-core/src/test/scala/maven2sbt/core/DependencySpec.scala
+++ b/modules/maven2sbt-core/src/test/scala/maven2sbt/core/DependencySpec.scala
@@ -43,7 +43,7 @@ object DependencySpec extends Properties {
     val expected                                                                        =
       RenderedString.noQuotesRequired(
         s""""$groupId" ${if (dependency.isScalaLib) "%%" else "%"} "$artifactId" % "$version"${Scope
-            .renderNonCompileWithPrefix(" % ", scope)}${Exclusion
+            .renderNonCompileWithPrefix(" % ", scope, propsName)}${Exclusion
             .renderExclusions(propsName, exclusions)
             .toQuotedString}""",
       )
@@ -85,7 +85,7 @@ object DependencySpec extends Properties {
     val expected                                                                        =
       RenderedString.noQuotesRequired(
         s""""$groupId" ${if (dependency.isScalaLib) "%%" else "%"} "$artifactId" % "$version"${Scope
-            .renderNonCompileWithPrefix(" % ", scope)}${Exclusion
+            .renderNonCompileWithPrefix(" % ", scope, propsName)}${Exclusion
             .renderExclusions(propsName, exclusions)
             .toQuotedString}""",
       )
@@ -109,12 +109,12 @@ object DependencySpec extends Properties {
     val libs     = Libs(List((Libs.LibValName("myLib"), myLib)))
     val expected = RenderedString.noQuotesRequired(
       if (myLib.scope === Scope.compile || myLib.scope === Scope.default) {
-        s"""${libsName.value}.myLib${Scope.renderNonCompileWithPrefix(" % ", scope)}${Exclusion
+        s"""${libsName.value}.myLib${Scope.renderNonCompileWithPrefix(" % ", scope, propsName)}${Exclusion
             .renderExclusions(propsName, myLib.exclusions.diff(exclusions))
             .toQuotedString}"""
       } else {
         s""""$groupId" ${if (dependency.isScalaLib) "%%" else "%"} "$artifactId" % "$version"${Scope
-            .renderNonCompileWithPrefix(" % ", scope)}${Exclusion
+            .renderNonCompileWithPrefix(" % ", scope, propsName)}${Exclusion
             .renderExclusions(propsName, exclusions)
             .toQuotedString}"""
       },
@@ -143,7 +143,7 @@ object DependencySpec extends Properties {
     val expected                                                                        =
       RenderedString.noQuotesRequired(
         s""""$groupId" ${if (dependency.isScalaLib) "%%" else "%"} "$artifactId" % "$version"${Scope
-            .renderNonCompileWithPrefix(" % ", scope)}${Exclusion
+            .renderNonCompileWithPrefix(" % ", scope, propsName)}${Exclusion
             .renderExclusions(propsName, exclusions)
             .toQuotedString}""",
       )
@@ -196,7 +196,7 @@ object DependencySpec extends Properties {
     val libs     = Libs(List((Libs.LibValName("myLib"), myLib)))
     val expected = RenderedString.noQuotesRequired(
       s""""$groupId" ${if (dependency.isScalaLib) "%%" else "%"} "$artifactId" % "$version"${Scope
-          .renderNonCompileWithPrefix(" % ", scope)}${Exclusion
+          .renderNonCompileWithPrefix(" % ", scope, propsName)}${Exclusion
           .renderExclusions(propsName, exclusions)
           .toQuotedString}""",
     )

--- a/modules/maven2sbt-core/src/test/scala/maven2sbt/core/LibsSpec.scala
+++ b/modules/maven2sbt-core/src/test/scala/maven2sbt/core/LibsSpec.scala
@@ -59,7 +59,7 @@ object LibsSpec extends Properties {
         )         = dependency.tupled
         depString = RenderedString.noQuotesRequired(
                       s""""$groupId" ${if (dependency.isScalaLib) "%%" else "%"} "$artifactId" % "$version"${Scope
-                          .renderNonCompileWithPrefix(" % ", scope)}${Exclusion
+                          .renderNonCompileWithPrefix(" % ", scope, propsName)}${Exclusion
                           .renderExclusions(propsName, exclusions)
                           .toQuotedString}""",
                     )

--- a/modules/maven2sbt-core/src/test/scala/maven2sbt/core/ScopeSpec.scala
+++ b/modules/maven2sbt-core/src/test/scala/maven2sbt/core/ScopeSpec.scala
@@ -2,7 +2,7 @@ package maven2sbt.core
 
 import hedgehog.*
 import hedgehog.runner.*
-import cats.syntax.all.*
+import maven2sbt.core.Props.PropsName
 
 /** @author Kevin Lee
   * @since 2019-04-21
@@ -15,7 +15,20 @@ object ScopeSpec extends Properties {
     (Scope.provided, "Provided"),
     (Scope.runtime, "Runtime"),
     (Scope.system, "sbt.Configurations.System"),
-    (Scope.Default, ""),
+    (Scope.default, ""),
+    (Scope.unknown("something else"), "something else"),
+    (Scope.unknown(raw"$${something.else}"), raw"$${something.else}"),
+  )
+
+  private val scopeAndRenderedNonCompileWithPrefix = List(
+    (Scope.compile, "Compile"),
+    (Scope.test, "Test"),
+    (Scope.provided, "Provided"),
+    (Scope.runtime, "Runtime"),
+    (Scope.system, "sbt.Configurations.System"),
+    (Scope.default, ""),
+    (Scope.unknown("something else"), "\"something else\""),
+    (Scope.unknown(raw"$${something.else}"), "props.somethingElse"),
   )
 
   private val mavenScopeAndScope = List(
@@ -25,13 +38,13 @@ object ScopeSpec extends Properties {
     ("runtime", Scope.runtime),
     ("system", Scope.system),
     ("", Scope.default),
+    ("something else", Scope.unknown("something else")),
   )
 
   override def tests: List[Test] = List(
     example("test scope render", testRender),
     property("test scope renderWithPrefix", testRenderWithPrefix),
-    example("test scope parse (valid)", testParseValid),
-    property("test scope parse (invalid)", testParseInvalid),
+    example("test scope parse", testParseValid),
   )
 
   def testRender: Result = Result.all(for {
@@ -42,26 +55,30 @@ object ScopeSpec extends Properties {
     prefix <- Gen.string(Gen.unicode, Range.linear(0, 20)).log("prefix")
   } yield {
     Result.all(
-      scopeAndRendered.map {
+      scopeAndRenderedNonCompileWithPrefix.map {
         case (scope, expected) =>
-          Scope.renderNonCompileWithPrefix(prefix, scope) ====
-            (if (scope === Scope.Default || scope === Scope.Compile) "" else s"$prefix$expected")
+          Scope.renderNonCompileWithPrefix(prefix, scope, PropsName("props")) ==== (scope match {
+            case Scope.Default | Scope.Compile =>
+              ""
+
+            case Scope.Unknown(_) =>
+              s"$prefix$expected"
+
+            case Scope.Test | Scope.Provided | Scope.Runtime | Scope.System =>
+              s"$prefix$expected"
+          })
       },
     )
   }
+
+  // TODO: Add more tests for scope rendering
 
   def testParseValid: Result =
     Result.all(
       mavenScopeAndScope.map {
         case (mavenScope, scope) =>
-          Scope.parse(mavenScope) ==== scope.asRight[String]
+          Scope.parse(mavenScope) ==== scope
       },
     )
 
-  def testParseInvalid: Property = for {
-    n          <- Gen.int(Range.linear(1, 1000)).log("n")
-    mavenScope <- Gen.string(Gen.unicode, Range.linear(1, 50)).map(_ + n.toString).log("mavenScope")
-  } yield {
-    Result.assert(Scope.parse(mavenScope).isLeft)
-  }
 }


### PR DESCRIPTION
Fix #339 - Update Scope handling including scope from props

Refactored Scope parsing and rendering methods to better handle unknown scopes. The methods now return a Scope object with an Unknown type instead of an error when an unrecognised scope is encountered. When the unknown scope is using props, it can be handled properly with this change.