### PR TITLE
maven2sbt v1.5.0

### DIFF
--- a/changelogs/1.5.0.md
+++ b/changelogs/1.5.0.md
@@ -1,0 +1,61 @@
+## [1.5.0](https://github.com/kevin-lee/maven2sbt/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+milestone%3Amilestone11) - 2023-07-12
+
+### Bug Fix
+* Fix: Issue with Unsupported scope (#339)
+
+### Improvement
+* Exclude should not have Scala binary version suffix (#327)
+
+  The old exclusions look like
+  ```scala
+  exclude("group-id", "artifact-id_${props.scalaBinaryVersion}")
+  ```
+  ```scala
+  excludeAll(
+    ExclusionRule(organization = "group-id", name = "artifact-id_${props.scalaBinaryVersion}"),
+    ExclusionRule(organization = "group-id2", name = "artifact-id2"),
+  )
+  ```
+  It is now done like these instead.
+  ```scala
+  excludeAll("group-id" %% "artifact-id")
+  ```
+  ```scala
+  excludeAll(
+    "group-id" %% "artifact-id",
+    "group-id2" % "artifact-id2",
+  )
+  ```
+  It is much cleaner this way.
+
+
+* Make `GlobalSettings.empty` constant (#285)
+  
+  Make `GlobalSettings.empty` constant.
+  `GlobalSettings.empty` is currently `def` so it creates a new instance of an empty `GlobalSettings` whenever `GlobalSettings.empty` is called. However, `GlobalSettings` is immutable so there can be only one instance used for any required empty `GlobalSettings`.
+
+### Internal Housekeeping
+
+* Upgrade libraries: `cats-effect`, `effectie`, `logger-f` and `extras` (#334)
+  * `cats-effect` to `3.4.8`
+  * `effectie` to `2.0.0-beta9`
+  * `logger-f` to `2.0.0-beta12`
+  * `extras` to `0.38.0`
+* Upgrade libraries (#332)
+  * cats-effect to `3.4.7`
+  * effectie to `2.0.0-beta6`
+  * logger-f to `2.0.0-beta9`
+  * extras to `0.31.0`
+* Add syntax for `Render` (#325)
+* Upgrade `cats-effect` to `3.4.4` (#318)
+* Upgrade GraalVM to `22.3.0` (#316)
+* Bump Scala 2 and libraries (#311)
+  * `2.12.17`
+  * `2.13.10`
+* Upgrade GraalVM to `22.2.0` and JVM to `17` (#308)
+* Remove `sbt-extras` (#306)
+* Upgrade `sbt-extras` script (#304)
+* Set up WartRemover for Scala 3 (#294)
+* Move all sub-projects to modules dir (#291)
+* Use [extras-cats](https://www.github.com/kevin-lee/extras) (#277)
+* Upgrade Scala 3 to `3.0.1` and Effectie to `1.14.0` (#275)


### PR DESCRIPTION
# maven2sbt v1.5.0
## [1.5.0](https://github.com/kevin-lee/maven2sbt/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+milestone%3Amilestone11) - 2023-07-12

### Bug Fix
* Fix: Issue with Unsupported scope (#339)

### Improvement
* Exclude should not have Scala binary version suffix (#327)

  The old exclusions look like
  ```scala
  exclude("group-id", "artifact-id_${props.scalaBinaryVersion}")
  ```
  ```scala
  excludeAll(
    ExclusionRule(organization = "group-id", name = "artifact-id_${props.scalaBinaryVersion}"),
    ExclusionRule(organization = "group-id2", name = "artifact-id2"),
  )
  ```
  It is now done like these instead.
  ```scala
  excludeAll("group-id" %% "artifact-id")
  ```
  ```scala
  excludeAll(
    "group-id" %% "artifact-id",
    "group-id2" % "artifact-id2",
  )
  ```
  It is much cleaner this way.


* Make `GlobalSettings.empty` constant (#285)
  
  Make `GlobalSettings.empty` constant.
  `GlobalSettings.empty` is currently `def` so it creates a new instance of an empty `GlobalSettings` whenever `GlobalSettings.empty` is called. However, `GlobalSettings` is immutable so there can be only one instance used for any required empty `GlobalSettings`.

### Internal Housekeeping

* Upgrade libraries: `cats-effect`, `effectie`, `logger-f` and `extras` (#334)
  * `cats-effect` to `3.4.8`
  * `effectie` to `2.0.0-beta9`
  * `logger-f` to `2.0.0-beta12`
  * `extras` to `0.38.0`
* Upgrade libraries (#332)
  * cats-effect to `3.4.7`
  * effectie to `2.0.0-beta6`
  * logger-f to `2.0.0-beta9`
  * extras to `0.31.0`
* Add syntax for `Render` (#325)
* Upgrade `cats-effect` to `3.4.4` (#318)
* Upgrade GraalVM to `22.3.0` (#316)
* Bump Scala 2 and libraries (#311)
  * `2.12.17`
  * `2.13.10`
* Upgrade GraalVM to `22.2.0` and JVM to `17` (#308)
* Remove `sbt-extras` (#306)
* Upgrade `sbt-extras` script (#304)
* Set up WartRemover for Scala 3 (#294)
* Move all sub-projects to modules dir (#291)
* Use [extras-cats](https://www.github.com/kevin-lee/extras) (#277)
* Upgrade Scala 3 to `3.0.1` and Effectie to `1.14.0` (#275)
