### PR TITLE
Update default version to 1.5.0 and URL in installation scripts

### DIFF
--- a/.scripts/install-graal-macos.sh
+++ b/.scripts/install-graal-macos.sh
@@ -4,9 +4,9 @@ set -eu
 
 app_executable_name=maven2sbt
 app_name=maven2sbt-cli
-app_version=${1:-1.4.0}
+app_version=${1:-1.5.0}
 app_package_file="${app_name}-macos-latest"
-download_url="https://github.com/Kevin-Lee/maven2sbt/releases/download/v${app_version}/${app_package_file}"
+download_url="https://github.com/kevin-lee/maven2sbt/releases/download/v${app_version}/${app_package_file}"
 
 usr_local_path="/usr/local"
 opt_location="${usr_local_path}/opt"

--- a/.scripts/install-graal-ubuntu.sh
+++ b/.scripts/install-graal-ubuntu.sh
@@ -4,9 +4,9 @@ set -eu
 
 app_executable_name=maven2sbt
 app_name=maven2sbt-cli
-app_version=${1:-1.4.0}
+app_version=${1:-1.5.0}
 app_package_file="${app_name}-ubuntu-latest"
-download_url="https://github.com/Kevin-Lee/maven2sbt/releases/download/v${app_version}/${app_package_file}"
+download_url="https://github.com/kevin-lee/maven2sbt/releases/download/v${app_version}/${app_package_file}"
 
 usr_local_path=${HOME}
 opt_location="${usr_local_path}/opt"

--- a/.scripts/install.sh
+++ b/.scripts/install.sh
@@ -4,10 +4,10 @@ set -eu
 
 app_executable_name=maven2sbt
 app_name=maven2sbt-cli
-app_version=${1:-1.4.0}
+app_version=${1:-1.5.0}
 versioned_app_name="${app_name}-${app_version}"
 app_zip_file="${versioned_app_name}.zip"
-download_url="https://github.com/Kevin-Lee/maven2sbt/releases/download/v${app_version}/${app_zip_file}"
+download_url="https://github.com/kevin-lee/maven2sbt/releases/download/v${app_version}/${app_zip_file}"
 
 usr_local_path="/usr/local"
 opt_location="${usr_local_path}/opt"


### PR DESCRIPTION
Update default version to 1.5.0 and URL in installation scripts

This commit modifies the .scripts/install-graal-ubuntu.sh, .scripts/install.sh, and .scripts/install-graal-macos.sh files. It updates the default app version from 1.4.0 to 1.5.0 and corrects the case of the username in the download URL. This is done to reflect the release of maven2sbt-cli version 1.5.0 and handle a possible case sensitivity issue that could prevent successful downloading of the package. [skip ci]