### PR TITLE
Close #349 - Upgrade libraries and sbt plugins

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ import SbtProjectInfo._
 
 ThisBuild / organization := "io.kevinlee"
 ThisBuild / scalaVersion := props.ProjectScalaVersion
-ThisBuild / developers := List(
+ThisBuild / developers   := List(
   Developer(
     props.GitHubUsername,
     "Kevin Lee",
@@ -10,17 +10,15 @@ ThisBuild / developers := List(
     url(s"https://github.com/${props.GitHubUsername}"),
   ),
 )
-ThisBuild / homepage := url(s"https://github.com/${props.GitHubUsername}/${props.RepoName}").some
-ThisBuild / scmInfo :=
+ThisBuild / homepage     := url(s"https://github.com/${props.GitHubUsername}/${props.RepoName}").some
+ThisBuild / scmInfo      :=
   ScmInfo(
     url(s"https://github.com/${props.GitHubUsername}/${props.RepoName}"),
     s"https://github.com/${props.GitHubUsername}/${props.RepoName}.git",
   ).some
-ThisBuild / licenses := List("MIT" -> url("http://opensource.org/licenses/MIT"))
+ThisBuild / licenses     := List("MIT" -> url("http://opensource.org/licenses/MIT"))
 
 ThisBuild / resolvers += "sonatype-snapshots" at s"https://${props.SonatypeCredentialHost}/content/repositories/snapshots"
-
-ThisBuild / useAggressiveScalacOptions := true
 
 ThisBuild / scalafixConfig := (
   if (scalaVersion.value.startsWith("3"))
@@ -32,8 +30,8 @@ ThisBuild / scalafixConfig := (
 lazy val maven2sbt = (project in file("."))
   .enablePlugins(DevOopsGitHubReleasePlugin, DocusaurPlugin)
   .settings(
-    name := props.RepoName,
-    libraryDependencies := libraryDependenciesPostProcess(scalaVersion.value, libraryDependencies.value),
+    name                     := props.RepoName,
+    libraryDependencies      := libraryDependenciesPostProcess(scalaVersion.value, libraryDependencies.value),
     /* GitHub Release { */
     devOopsPackagedArtifacts := List(
       s"modules/${props.RepoName}-cli/target/universal/${name.value}*.zip",
@@ -41,8 +39,8 @@ lazy val maven2sbt = (project in file("."))
     ),
     /* } GitHub Release */
     /* Website { */
-    docusaurDir := (ThisBuild / baseDirectory).value / "website",
-    docusaurBuildDir := docusaurDir.value / "build",
+    docusaurDir              := (ThisBuild / baseDirectory).value / "website",
+    docusaurBuildDir         := docusaurDir.value / "build",
     /* } Website */
   )
   .settings(mavenCentralPublishSettings)
@@ -53,7 +51,7 @@ lazy val core = module("core")
   .enablePlugins(BuildInfoPlugin)
   .settings(
 //    resolvers += Resolver.sonatypeRepo("snapshots"),
-    crossScalaVersions := props.CrossScalaVersions,
+    crossScalaVersions  := props.CrossScalaVersions,
     libraryDependencies ++= {
       val scalaV = scalaVersion.value
       if (scalaV.startsWith("3"))
@@ -67,9 +65,9 @@ lazy val core = module("core")
     libraryDependencies := libraryDependenciesPostProcess(scalaVersion.value, libraryDependencies.value),
     wartremoverExcluded ++= List(sourceManaged.value),
     /* Build Info { */
-    buildInfoKeys := Seq[BuildInfoKey](name, version, scalaVersion, sbtVersion),
-    buildInfoObject := "Maven2SbtBuildInfo",
-    buildInfoPackage := s"${props.RepoName}.info",
+    buildInfoKeys       := Seq[BuildInfoKey](name, version, scalaVersion, sbtVersion),
+    buildInfoObject     := "Maven2SbtBuildInfo",
+    buildInfoPackage    := s"${props.RepoName}.info",
     buildInfoOptions += BuildInfoOption.ToJson,
     /* } Build Info */
   )
@@ -79,14 +77,14 @@ lazy val pirate = ProjectRef(props.pirateUri, "pirate-scalaz")
 lazy val cli = module("cli")
   .enablePlugins(JavaAppPackaging, NativeImagePlugin)
   .settings(
-    libraryDependencies := libraryDependenciesPostProcess(scalaVersion.value, libraryDependencies.value),
-    scalaVersion := (ThisBuild / scalaVersion).value,
-    maintainer := "Kevin Lee <kevin.code@kevinlee.io>",
-    packageSummary := "Maven2Sbt",
-    packageDescription := "A tool to convert Maven pom.xml into sbt build.sbt",
+    libraryDependencies  := libraryDependenciesPostProcess(scalaVersion.value, libraryDependencies.value),
+    scalaVersion         := (ThisBuild / scalaVersion).value,
+    maintainer           := "Kevin Lee <kevin.code@kevinlee.io>",
+    packageSummary       := "Maven2Sbt",
+    packageDescription   := "A tool to convert Maven pom.xml into sbt build.sbt",
     executableScriptName := props.ExecutableScriptName,
-    nativeImageVersion := "22.3.0",
-    nativeImageJvm := "graalvm-java17",
+    nativeImageVersion   := "22.3.0",
+    nativeImageJvm       := "graalvm-java17",
     nativeImageOptions ++= Seq(
       "-H:+ReportExceptionStackTraces",
       "--initialize-at-build-time",
@@ -124,29 +122,30 @@ lazy val props =
     val ExecutableScriptName = RepoName
 
     val SonatypeCredentialHost = "s01.oss.sonatype.org"
-    val SonatypeRepository = s"https://$SonatypeCredentialHost/service/local"
+    val SonatypeRepository     = s"https://$SonatypeCredentialHost/service/local"
 
     val Scala2Version       = "2.13.10"
-    val DottyVersion        = "3.2.2"
-    val CrossScalaVersions  = List("2.12.17", Scala2Version, DottyVersion).distinct
+    val Scala3Version       = "3.2.2"
+    val CrossScalaVersions  = List("2.12.17", Scala2Version, Scala3Version).distinct
     val ProjectScalaVersion = Scala2Version
+//    val ProjectScalaVersion = Scala3Version
 
     val CatsVersion       = "2.9.0"
-    val CatsEffectVersion = "3.5.1"
+    val CatsEffectVersion = "3.5.2"
 
     val HedgehogVersion = "0.10.1"
 
 //    val canEqualVersion = "0.1.0"
 
-    val EffectieVersion = "2.0.0-beta10"
-    val LoggerFVersion  = "2.0.0-beta15"
+    val EffectieVersion = "2.0.0-beta13"
+    val LoggerFVersion  = "2.0.0-beta23"
 
-    val PirateVersion = "a3415ad22371820a8c03b62ce9d3e4f467575681"
+    val PirateVersion = "faff703b67fd10199098e806a3f6858982823461"
     val pirateUri     = uri(s"https://github.com/$GitHubUsername/pirate.git#$PirateVersion")
 
     val ScalaXml2Version = "2.1.0"
 
-    val ExtrasVersion = "0.39.0"
+    val ExtrasVersion = "0.44.0"
 
   }
 
@@ -193,24 +192,29 @@ def libraryDependenciesPostProcess(
     libraries
   }
 
-lazy val scala3cLanguageOptions =
-  List(
-    "dynamics",
-    "existentials",
-    "higherKinds",
-    "reflectiveCalls",
-    "experimental.macros",
-    "implicitConversions",
-  ).map("-language:" + _)
+//lazy val scala3cLanguageOptions =
+//  List(
+//    "dynamics",
+//    "existentials",
+//    "higherKinds",
+//    "reflectiveCalls",
+//    "experimental.macros",
+//    "implicitConversions",
+//  ).map("-language:" + _)
 
 def scalacOptionsPostProcess(scalaVersion: String, options: Seq[String]): Seq[String] =
   if (scalaVersion.startsWith("3.")) {
-    scala3cLanguageOptions ++
-      options.filterNot(o =>
-        o == "-language:dynamics,existentials,higherKinds,reflectiveCalls,experimental.macros,implicitConversions" || o == "UTF-8",
-      )
+    options
+//    scala3cLanguageOptions ++
+//      options.filterNot(o =>
+//        o == "-language:dynamics,existentials,higherKinds,reflectiveCalls,experimental.macros,implicitConversions" || o == "UTF-8",
+//      )
+  } else if (scalaVersion.startsWith("2.13")) {
+    "-Xsource:3" +: "-P:kind-projector:underscore-placeholders" +: "-Ymacro-annotations" +:
+      options.filterNot(_ == "-Xlint:package-object-classes")
   } else {
-    "-Xsource:3" +: options.filterNot(_ == "UTF-8")
+    "-Xsource:3" +: "-P:kind-projector:underscore-placeholders" +:
+      options.filterNot(_ == "-Xlint:package-object-classes")
   }
 
 lazy val mavenCentralPublishSettings: SettingsDefinition = List(
@@ -224,10 +228,10 @@ def module(projectName: String): Project = {
   val prefixedName = prefixedProjectName(projectName)
   Project(projectName, file(s"modules/$prefixedName"))
     .settings(
-      name := prefixedName,
+      name                           := prefixedName,
       libraryDependencies ++= libs.hedgehogLibs,
-      scalacOptions := scalacOptionsPostProcess(scalaVersion.value, scalacOptions.value).distinct,
-      scalafixConfig := (
+      scalacOptions                  := scalacOptionsPostProcess(scalaVersion.value, scalacOptions.value).distinct,
+      scalafixConfig                 := (
         if (scalaVersion.value.startsWith("3"))
           ((ThisBuild / baseDirectory).value / ".scalafix-scala3.conf").some
         else
@@ -242,21 +246,22 @@ def module(projectName: String): Project = {
         else
           Seq.empty
       },
+      Test / compile / scalacOptions := (Test / compile / scalacOptions).value.filterNot(_ == "-Wnonunit-statement"),
       /* WartRemover and scalacOptions { */
       //      , Compile / compile / wartremoverErrors ++= commonWarts((update / scalaBinaryVersion).value)
       //      , Test / compile / wartremoverErrors ++= commonWarts((update / scalaBinaryVersion).value)
       wartremoverErrors ++= commonWarts((update / scalaVersion).value),
       //            , wartremoverErrors ++= Warts.all
-      Compile / console / wartremoverErrors := List.empty,
+      Compile / console / wartremoverErrors   := List.empty,
       Compile / console / wartremoverWarnings := List.empty,
-      Compile / console / scalacOptions :=
+      Compile / console / scalacOptions       :=
         (console / scalacOptions)
           .value
           .distinct
           .filterNot(option => option.contains("wartremover") || option.contains("import")),
-      Test / console / wartremoverErrors := List.empty,
-      Test / console / wartremoverWarnings := List.empty,
-      Test / console / scalacOptions :=
+      Test / console / wartremoverErrors      := List.empty,
+      Test / console / wartremoverWarnings    := List.empty,
+      Test / console / scalacOptions          :=
         (console / scalacOptions)
           .value
           .distinct
@@ -264,6 +269,6 @@ def module(projectName: String): Project = {
       //      , Compile / compile / wartremoverExcluded += sourceManaged.value
       //      , Test / compile / wartremoverExcluded += sourceManaged.value
       /* } WartRemover and scalacOptions */
-      licenses := List("MIT" -> url("http://opensource.org/licenses/MIT")),
+      licenses                                := List("MIT" -> url("http://opensource.org/licenses/MIT")),
     )
 }

--- a/modules/maven2sbt-cli/src/main/scala/maven2sbt/cli/MainIo.scala
+++ b/modules/maven2sbt-cli/src/main/scala/maven2sbt/cli/MainIo.scala
@@ -60,8 +60,7 @@ trait MainIo[A] extends IOApp {
                          err =>
                            ConsoleFx[IO].putErrStrLn(Maven2SbtError.render(err)) *>
                              IO.pure(ExitCode.Error),
-                         _.fold(IO.pure(ExitCode.Success))(msg => ConsoleFx[IO].putStrLn(msg) *> IO.pure(ExitCode.Success),
-                         ),
+                         _.fold(IO.pure(ExitCode.Success))(msg => ConsoleFx[IO].putStrLn(msg) *> IO.pure(ExitCode.Success)),
                        )
     } yield exitCode
   }

--- a/modules/maven2sbt-cli/src/main/scala/maven2sbt/cli/Maven2SbtArgs.scala
+++ b/modules/maven2sbt-cli/src/main/scala/maven2sbt/cli/Maven2SbtArgs.scala
@@ -1,6 +1,7 @@
 package maven2sbt.cli
 
-import maven2sbt.core.{Libs, Props, ScalaBinaryVersion, ScalaVersion}
+import maven2sbt.core.{Libs, Props}
+import maven2sbt.core.data.{ScalaBinaryVersion, ScalaVersion}
 
 import java.io.File
 

--- a/modules/maven2sbt-cli/src/main/scala/maven2sbt/cli/Maven2SbtArgsParser.scala
+++ b/modules/maven2sbt-cli/src/main/scala/maven2sbt/cli/Maven2SbtArgsParser.scala
@@ -5,7 +5,8 @@ import Scalaz.*
 import pirate.*
 import Pirate.*
 import cats.Show
-import maven2sbt.core.{Libs, Props, ScalaBinaryVersion, ScalaVersion}
+import maven2sbt.core.{Libs, Props}
+import maven2sbt.core.data.{ScalaBinaryVersion, ScalaVersion}
 import maven2sbt.info.Maven2SbtBuildInfo
 
 import java.io.File

--- a/modules/maven2sbt-core/src/main/scala-2.12_2.13/maven2sbt/core/data.scala
+++ b/modules/maven2sbt-core/src/main/scala-2.12_2.13/maven2sbt/core/data.scala
@@ -1,4 +1,4 @@
-package maven2sbt
+package maven2sbt.core
 
 import cats.*
 import io.estatico.newtype.macros.*
@@ -8,7 +8,7 @@ import just.fp.Named
 /** @author Kevin Lee
   * @since 2019-04-22
   */
-package object core {
+object data {
 
   @newtype case class GroupId(value: String)
 

--- a/modules/maven2sbt-core/src/main/scala-3/maven2sbt/core/data.scala
+++ b/modules/maven2sbt-core/src/main/scala-3/maven2sbt/core/data.scala
@@ -1,4 +1,4 @@
-package maven2sbt
+package maven2sbt.core
 
 import just.fp.Named
 
@@ -7,7 +7,7 @@ import cats.*
 /** @author Kevin Lee
   * @since 2019-04-22
   */
-package object core {
+object data {
 
   type GroupId = GroupId.GroupId
   object GroupId {

--- a/modules/maven2sbt-core/src/main/scala/maven2sbt/core/BuildSbt.scala
+++ b/modules/maven2sbt-core/src/main/scala/maven2sbt/core/BuildSbt.scala
@@ -4,6 +4,7 @@ import BuildSbt.*
 import cats.syntax.all.*
 import just.fp.Named
 import maven2sbt.core.syntax.render.*
+import maven2sbt.core.data.*
 
 /** @author Kevin Lee
   * @since 2020-01-29

--- a/modules/maven2sbt-core/src/main/scala/maven2sbt/core/Dependency.scala
+++ b/modules/maven2sbt-core/src/main/scala/maven2sbt/core/Dependency.scala
@@ -1,5 +1,7 @@
 package maven2sbt.core
 
+import maven2sbt.core.data.*
+
 /** @author Kevin Lee
   * @since 2019-04-21
   */

--- a/modules/maven2sbt-core/src/main/scala/maven2sbt/core/DependencyPlus.scala
+++ b/modules/maven2sbt-core/src/main/scala/maven2sbt/core/DependencyPlus.scala
@@ -4,6 +4,8 @@ import cats.Show
 import cats.syntax.all.*
 import just.fp.Named
 
+import maven2sbt.core.data.*
+
 import scala.language.postfixOps
 import scala.xml.Node
 
@@ -180,7 +182,8 @@ trait DependencyPlus { self =>
             } else {
               if (libExclusions.length === exclusions.length && libExclusions.diff(exclusions).isEmpty)
                 RenderedString.noQuotesRequired(
-                  s"""${libsName.value}.${libValName.value}${Scope.renderNonCompileWithPrefix(" % ", scope, propsName)}""",
+                  s"""${libsName.value}.${libValName.value}${Scope
+                      .renderNonCompileWithPrefix(" % ", scope, propsName)}""",
                 )
               else if (libExclusions.isEmpty)
                 RenderedString.noQuotesRequired(

--- a/modules/maven2sbt-core/src/main/scala/maven2sbt/core/Exclusion.scala
+++ b/modules/maven2sbt-core/src/main/scala/maven2sbt/core/Exclusion.scala
@@ -4,6 +4,8 @@ import StringUtils.*
 import cats.*
 import cats.syntax.show.*
 
+import maven2sbt.core.data.*
+
 /** @author Kevin Lee
   * @since 2019-04-22
   */

--- a/modules/maven2sbt-core/src/main/scala/maven2sbt/core/LibsPlus.scala
+++ b/modules/maven2sbt-core/src/main/scala/maven2sbt/core/LibsPlus.scala
@@ -3,6 +3,8 @@ package maven2sbt.core
 import cats.Show
 import cats.syntax.show.*
 
+import maven2sbt.core.data.*
+
 import scala.xml.Node
 
 import Libs.*

--- a/modules/maven2sbt-core/src/main/scala/maven2sbt/core/Maven2Sbt.scala
+++ b/modules/maven2sbt-core/src/main/scala/maven2sbt/core/Maven2Sbt.scala
@@ -6,6 +6,8 @@ import effectie.core.*
 import effectie.syntax.fx.*
 import extras.cats.syntax.all.*
 
+import maven2sbt.core.data.*
+
 import java.io.{File, InputStream}
 import scala.xml.*
 

--- a/modules/maven2sbt-core/src/main/scala/maven2sbt/core/ProjectInfo.scala
+++ b/modules/maven2sbt-core/src/main/scala/maven2sbt/core/ProjectInfo.scala
@@ -2,6 +2,8 @@ package maven2sbt.core
 
 import cats.Show
 
+import maven2sbt.core.data.*
+
 import scala.language.postfixOps
 import scala.xml.Elem
 

--- a/modules/maven2sbt-core/src/main/scala/maven2sbt/core/Prop.scala
+++ b/modules/maven2sbt-core/src/main/scala/maven2sbt/core/Prop.scala
@@ -1,5 +1,6 @@
 package maven2sbt.core
 
+import maven2sbt.core.data.*
 final case class Prop(name: Prop.PropName, value: Prop.PropValue)
 
 object Prop {

--- a/modules/maven2sbt-core/src/main/scala/maven2sbt/core/PropsPlus.scala
+++ b/modules/maven2sbt-core/src/main/scala/maven2sbt/core/PropsPlus.scala
@@ -1,6 +1,7 @@
 package maven2sbt.core
 
 import maven2sbt.core.Props.PropsName
+import maven2sbt.core.data.*
 
 /** @author Kevin Lee
   * @since 2021-03-10

--- a/modules/maven2sbt-core/src/main/scala/maven2sbt/core/RepositoryPlus.scala
+++ b/modules/maven2sbt-core/src/main/scala/maven2sbt/core/RepositoryPlus.scala
@@ -4,6 +4,7 @@ import cats.Show
 import cats.syntax.all.none
 import just.fp.Named
 import maven2sbt.core.Repository.{RepoId, RepoName, RepoUrl}
+import maven2sbt.core.data.*
 
 import scala.xml.Elem
 

--- a/modules/maven2sbt-core/src/main/scala/maven2sbt/core/Scope.scala
+++ b/modules/maven2sbt-core/src/main/scala/maven2sbt/core/Scope.scala
@@ -4,6 +4,8 @@ import cats.Show
 import cats.kernel.Eq
 import cats.syntax.all.*
 
+import maven2sbt.core.data.*
+
 /** @author Kevin Lee
   * @since 2019-04-21
   */

--- a/modules/maven2sbt-core/src/test/scala/maven2sbt/core/BuildSbtSpec.scala
+++ b/modules/maven2sbt-core/src/test/scala/maven2sbt/core/BuildSbtSpec.scala
@@ -3,6 +3,7 @@ package maven2sbt.core
 import cats.syntax.all.*
 import hedgehog.*
 import hedgehog.runner.*
+import maven2sbt.core.data.*
 
 /** @author Kevin Lee
   * @since 2020-09-05

--- a/modules/maven2sbt-core/src/test/scala/maven2sbt/core/DependencySpec.scala
+++ b/modules/maven2sbt-core/src/test/scala/maven2sbt/core/DependencySpec.scala
@@ -3,6 +3,7 @@ package maven2sbt.core
 import cats.syntax.all.*
 import hedgehog.*
 import hedgehog.runner.*
+import maven2sbt.core.data.*
 
 import scala.xml.Elem
 

--- a/modules/maven2sbt-core/src/test/scala/maven2sbt/core/ExclusionSpec.scala
+++ b/modules/maven2sbt-core/src/test/scala/maven2sbt/core/ExclusionSpec.scala
@@ -2,6 +2,7 @@ package maven2sbt.core
 
 import hedgehog.*
 import hedgehog.runner.*
+import maven2sbt.core.data.*
 
 /** @author Kevin Lee
   * @since 2019-04-22

--- a/modules/maven2sbt-core/src/test/scala/maven2sbt/core/Gens.scala
+++ b/modules/maven2sbt-core/src/test/scala/maven2sbt/core/Gens.scala
@@ -1,9 +1,10 @@
 package maven2sbt.core
 
-import hedgehog.*
 import cats.syntax.all.*
-import maven2sbt.core.Repository.{RepoId, RepoName, RepoUrl}
+import hedgehog.*
 import maven2sbt.core.Prop as M2sProp
+import maven2sbt.core.Repository.{RepoId, RepoName, RepoUrl}
+import maven2sbt.core.data.*
 
 import scala.util.Random
 

--- a/modules/maven2sbt-core/src/test/scala/maven2sbt/core/LibsSpec.scala
+++ b/modules/maven2sbt-core/src/test/scala/maven2sbt/core/LibsSpec.scala
@@ -3,6 +3,7 @@ package maven2sbt.core
 import cats.syntax.all.*
 import hedgehog.*
 import hedgehog.runner.*
+import maven2sbt.core.data.*
 
 import scala.xml.Elem
 

--- a/modules/maven2sbt-core/src/test/scala/maven2sbt/core/ProjectInfoSpec.scala
+++ b/modules/maven2sbt-core/src/test/scala/maven2sbt/core/ProjectInfoSpec.scala
@@ -2,6 +2,7 @@ package maven2sbt.core
 
 import hedgehog.*
 import hedgehog.runner.*
+import maven2sbt.core.data.*
 
 import scala.xml.*
 

--- a/modules/maven2sbt-core/src/test/scala/maven2sbt/core/PropSpec.scala
+++ b/modules/maven2sbt-core/src/test/scala/maven2sbt/core/PropSpec.scala
@@ -3,6 +3,7 @@ package maven2sbt.core
 import hedgehog.*
 import hedgehog.runner.*
 import maven2sbt.core.Prop as M2sProp
+import maven2sbt.core.data.*
 
 object PropSpec extends Properties {
 

--- a/modules/maven2sbt-core/src/test/scala/maven2sbt/core/PropsSpec.scala
+++ b/modules/maven2sbt-core/src/test/scala/maven2sbt/core/PropsSpec.scala
@@ -3,6 +3,7 @@ package maven2sbt.core
 import hedgehog.*
 import hedgehog.runner.*
 import maven2sbt.core.Prop as M2sProp
+import maven2sbt.core.data.*
 
 /** @author Kevin Lee
   * @since 2020-12-13
@@ -24,9 +25,8 @@ object PropsSpec extends Properties {
       case (mavenProperty, expectedProp) =>
         (
           mavenProperty,
-          s"""val ${expectedProp
-              .name
-              .propName} = ${StringUtils.renderWithProps(propsName, expectedProp.value.propValue).toQuotedString}""",
+          s"""val ${expectedProp.name.propName} = """ +
+            StringUtils.renderWithProps(propsName, expectedProp.value.propValue).toQuotedString,
         )
     }.unzip
     val indent                 = " " * indentSize

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -7,13 +7,13 @@ addSbtPlugin("org.scoverage"   % "sbt-coveralls"       % "1.3.5")
 addSbtPlugin("com.github.sbt"  % "sbt-native-packager" % "1.9.11")
 addSbtPlugin("org.scalameta"   % "sbt-native-image"    % "0.3.0")
 
-val sbtDevOopsVersion = "2.24.0"
+val sbtDevOopsVersion = "3.0.0"
 addSbtPlugin("io.kevinlee" % "sbt-devoops-scala"     % sbtDevOopsVersion)
 addSbtPlugin("io.kevinlee" % "sbt-devoops-sbt-extra" % sbtDevOopsVersion)
 addSbtPlugin("io.kevinlee" % "sbt-devoops-github"    % sbtDevOopsVersion)
 addSbtPlugin("io.kevinlee" % "sbt-devoops-starter"   % sbtDevOopsVersion)
 
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.10.0")
-addSbtPlugin("io.kevinlee"  % "sbt-docusaur"  % "0.13.0")
+addSbtPlugin("io.kevinlee"  % "sbt-docusaur"  % "0.15.0")
 
-addSbtPlugin("io.github.davidgregory084" % "sbt-tpolecat" % "0.4.1")
+addSbtPlugin("org.typelevel" % "sbt-tpolecat" % "0.5.0")


### PR DESCRIPTION
Close #349 - Upgrade libraries and sbt plugins
* cats-effect to `3.5.2`
* effectie to `2.0.0-beta13`
* logger-f to `2.0.0-beta23`
* extras to `0.44.0`
* pirate to `faff703b67fd10199098e806a3f6858982823461`
* sbt-devoops to `3.0.0`
* sbt-docusaur to `0.15.0`
* sbt-tpolecat to `0.5.0`

Update the broken code in accordance with the new versions of the libraries