### PR TITLE
Upgrade sbt to 1.11.0 and the sbt-ci-release plugin to 1.11.0 / clean up unused build settings related to the old Maven Central (OSSRH)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,8 +2,8 @@ name: Release
 
 on:
   push:
-#    branches:
-#      - main
+    branches:
+      - main
     tags:
       - '*'
 
@@ -22,7 +22,7 @@ jobs:
 
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v4
       - uses: actions/setup-java@v4
         with:
           java-version: ${{ env.GRAALVM_JAVA_VERSION }}
@@ -42,12 +42,13 @@ jobs:
             devOopsGitHubRelease
 
   publish:
+    if: startsWith(github.ref, 'refs/tags/v')
     needs: gh-release
 
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - uses: actions/setup-java@v4
@@ -83,12 +84,13 @@ jobs:
 
 
   packager-gh-release:
+    if: startsWith(github.ref, 'refs/tags/v')
     needs: gh-release
 
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - uses: actions/setup-java@v4
@@ -103,7 +105,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.RELEASE_AUTH_TOKEN_GITHUB }}
         run: |
-          echo "Run] sbt ci-release"
+          echo "Run] sbt to publish artifacts to GitHub Release"
           export SOURCE_DATE_EPOCH=$(date +%s)
           echo "SOURCE_DATE_EPOCH=$SOURCE_DATE_EPOCH"
           echo 'sbt -J-XX:MaxMetaspaceSize=1024m -J-Xmx2048m ++${{ env.CLI_SCALA_VERSION }}! -v clean test universal:packageBin devOopsGitHubReleaseUploadArtifacts'
@@ -119,6 +121,7 @@ jobs:
 
 
   graalvm-gh-release:
+    if: startsWith(github.ref, 'refs/tags/v')
     needs: gh-release
     runs-on: ${{ matrix.os.value }}
     strategy:
@@ -131,7 +134,7 @@ jobs:
           - { name: "macOS 15 Apple Silicon", value: "macos-15",     bin-suffix: "-macos-15-arm64" }
         run-binary: [maven2sbt-cli]
     steps:
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - uses: actions/setup-java@v4
@@ -171,6 +174,7 @@ jobs:
             devOopsGitHubReleaseUploadArtifacts
 
   graalvm-win-gh-release:
+    if: startsWith(github.ref, 'refs/tags/v')
     needs: gh-release
     runs-on: ${{ matrix.os }}
     strategy:
@@ -182,7 +186,7 @@ jobs:
       - name: Configure git
         run: "git config --global core.autocrlf false"
         shell: bash
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - uses: olafurpg/setup-scala@v10
@@ -229,3 +233,45 @@ jobs:
             -J-Xmx2048m \
             devOopsGitHubReleaseUploadArtifacts
 
+  publish-snapshot:
+    if: startsWith(github.ref, 'refs/heads/')
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-java@v4
+        with:
+          java-version: ${{ env.GRAALVM_JAVA_VERSION }}
+          distribution: ${{ env.GRAALVM_JAVA_DISTRIBUTION }}
+          cache: sbt
+      - uses: sbt/setup-sbt@v1
+
+      - uses: olafurpg/setup-gpg@v3
+
+      - name: "sbt ci-release (no tag) - ${{ github.run_number }}"
+        if: startsWith(github.ref, 'refs/heads/')
+        env:
+          PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
+          PGP_SECRET: ${{ secrets.PGP_SECRET }}
+          SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
+          SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
+        run: |
+          echo "Run] sbt ci-release SNAPSHOT"
+          
+          export JVM_OPTS="-Xss64m -Xms1024m -XX:MaxMetaspaceSize=2G -Xmx4G -XX:MaxInlineLevel=18 -XX:+UnlockExperimentalVMOptions -XX:+UseJVMCICompiler"
+          echo "JVM_OPTS=$JVM_OPTS"
+          echo "SBT_OPTS=${SBT_OPTS}"
+          
+          export SOURCE_DATE_EPOCH=$(date +%s)
+          echo "SOURCE_DATE_EPOCH=$SOURCE_DATE_EPOCH"
+          
+          echo 'sbt -v clean +packagedArtifacts ci-release'
+          sbt \
+            -v \
+            clean \
+            +test \
+            +packagedArtifacts \
+            ci-release

--- a/build.sbt
+++ b/build.sbt
@@ -18,8 +18,6 @@ ThisBuild / scmInfo      :=
   ).some
 ThisBuild / licenses     := List("MIT" -> url("http://opensource.org/licenses/MIT"))
 
-ThisBuild / resolvers += "sonatype-snapshots" at s"https://${props.SonatypeCredentialHost}/content/repositories/snapshots"
-
 ThisBuild / scalafixConfig := (
   if (scalaVersion.value.startsWith("3"))
     ((ThisBuild / baseDirectory).value / ".scalafix-scala3.conf").some
@@ -43,14 +41,12 @@ lazy val maven2sbt = (project in file("."))
     docusaurBuildDir         := docusaurDir.value / "build",
     /* } Website */
   )
-  .settings(mavenCentralPublishSettings)
   .settings(noPublish)
   .aggregate(core, cli)
 
 lazy val core = module("core")
   .enablePlugins(BuildInfoPlugin)
   .settings(
-//    resolvers += Resolver.sonatypeRepo("snapshots"),
     crossScalaVersions  := props.CrossScalaVersions,
     libraryDependencies ++= {
       val scalaV = scalaVersion.value
@@ -223,13 +219,6 @@ def scalacOptionsPostProcess(scalaVersion: String, options: Seq[String]): Seq[St
     "-Xsource:3" +: "-P:kind-projector:underscore-placeholders" +:
       options.filterNot(_ == "-Xlint:package-object-classes")
   }
-
-lazy val mavenCentralPublishSettings: SettingsDefinition = List(
-  /* Publish to Maven Central { */
-  sonatypeCredentialHost := props.SonatypeCredentialHost,
-  sonatypeRepository     := props.SonatypeRepository,
-  /* } Publish to Maven Central */
-)
 
 def module(projectName: String): Project = {
   val prefixedName = prefixedProjectName(projectName)

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.10.11
+sbt.version=1.11.0

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,6 @@
 logLevel := sbt.Level.Warn
 
-addSbtPlugin("com.github.sbt"    % "sbt-ci-release"      % "1.9.3")
+addSbtPlugin("com.github.sbt"  % "sbt-ci-release"      % "1.11.0")
 addSbtPlugin("org.wartremover" % "sbt-wartremover"     % "3.3.1")
 addSbtPlugin("org.scoverage"   % "sbt-scoverage"       % "2.3.1")
 addSbtPlugin("org.scoverage"   % "sbt-coveralls"       % "1.3.15")


### PR DESCRIPTION
Upgrade sbt to 1.11.0 and the sbt-ci-release plugin to 1.11.0 / clean up unused build settings related to the old Maven Central (OSSRH)

Due to the end-of-life (sunset) of OSSRH, upgrading sbt to 1.11.0 and sbt-ci-release to 1.11.0 was required in order to publish artifacts to the Central Publisher Portal (Maven Central).